### PR TITLE
C# Formatting and Benchmark Updates

### DIFF
--- a/CSharp/.editorconfig
+++ b/CSharp/.editorconfig
@@ -1,0 +1,119 @@
+# Rules in this file were initially inferred by Visual Studio IntelliCode from the C:\Users\mepengadmin\Documents\Projects\Clipper2-DJGosnell\CSharp\Clipper2Lib\ codebase based on best match to current usage at 4/6/2022
+# You can modify the rules from these initially generated values to suit your own policies
+# You can learn more about editorconfig here: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+[*.cs]
+
+
+#Core editorconfig formatting - indentation
+
+#use soft tabs (spaces) for indentation
+indent_style = space
+
+#Formatting - indentation options
+
+#indent switch case contents.
+csharp_indent_case_contents = true
+#indent switch labels
+csharp_indent_switch_labels = true
+
+#Formatting - new line options
+
+#place else statements on a new line
+csharp_new_line_before_else = true
+#require members of object intializers to be on separate lines
+csharp_new_line_before_members_in_object_initializers = true
+#require braces to be on a new line for object_collection_array_initializers, methods, types, and properties (also known as "Allman" style)
+csharp_new_line_before_open_brace = all
+
+#Formatting - organize using options
+
+#sort System.* using directives alphabetically, and place them before other usings
+dotnet_sort_system_directives_first = true
+
+#Formatting - spacing options
+
+#require a space between a cast and the value
+csharp_space_after_cast = true
+#require a space after a keyword in a control flow statement such as a for loop
+csharp_space_after_keywords_in_control_flow_statements = true
+#remove space within empty argument list parentheses
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+#remove space between method call name and opening parenthesis
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+#do not place space characters after the opening parenthesis and before the closing parenthesis of a method call
+csharp_space_between_method_call_parameter_list_parentheses = false
+#remove space within empty parameter list parentheses for a method declaration
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+#place a space character after the opening parenthesis and before the closing parenthesis of a method declaration parameter list.
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+#Formatting - wrapping options
+
+#leave code block on single line
+csharp_preserve_single_line_blocks = true
+#leave statements and member declarations on the same line
+csharp_preserve_single_line_statements = true
+
+#Style - Code block preferences
+
+#prefer no curly braces if allowed
+csharp_prefer_braces = false:suggestion
+
+#Style - expression bodied member options
+
+#prefer expression-bodied members for accessors
+csharp_style_expression_bodied_accessors = true:suggestion
+#prefer block bodies for methods
+csharp_style_expression_bodied_methods = false:suggestion
+#prefer block bodies for operators
+csharp_style_expression_bodied_operators = false:suggestion
+#prefer expression-bodied members for properties
+csharp_style_expression_bodied_properties = true:suggestion
+
+#Style - expression level options
+
+#prefer the language keyword for member access expressions, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+#Style - Expression-level  preferences
+
+#prefer objects to be initialized using object initializers when possible
+dotnet_style_object_initializer = true:suggestion
+
+#Style - implicit and explicit types
+
+#prefer explicit type over var in all cases, unless overridden by another code style rule
+csharp_style_var_elsewhere = false:suggestion
+#prefer explicit type over var to declare variables with built-in system types such as int
+csharp_style_var_for_built_in_types = false:suggestion
+#prefer explicit type over var when the type is already mentioned on the right-hand side of a declaration
+csharp_style_var_when_type_is_apparent = false:suggestion
+
+#Style - language keyword and framework type options
+
+#prefer the language keyword for local variables, method parameters, and class members, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+
+#Style - modifier options
+
+#prefer accessibility modifiers to be declared except for public interface members. This will currently not differ from always and will act as future proofing for if C# adds default interface methods.
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+#Style - Modifier preferences
+
+#when this rule is set to a list of modifiers, prefer the specified ordering.
+csharp_preferred_modifier_order = public,private,internal,static,readonly,override:suggestion
+
+#Style - Pattern matching
+
+#prefer pattern matching instead of is expression with type casts
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+
+#Style - qualification options
+
+#prefer fields not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_field = false:suggestion
+#prefer methods not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_method = false:suggestion
+#prefer properties not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_property = false:suggestion

--- a/CSharp/Clipper2Lib.Benchmark/Benchmarks.cs
+++ b/CSharp/Clipper2Lib.Benchmark/Benchmarks.cs
@@ -13,79 +13,75 @@ namespace Clipper2Lib.Benchmark
     {
         private Paths64 _subj;
         private Paths64 _clip;
-        private Paths64 _pathInflate;
+        private Paths64 _solution;
+        private const int DisplayWidth = 800;
+        private const int DisplayHeight = 600;
+
+        [Params(1000, 2000, 3000, 4000)]
+        public int EdgeCount { get; set; }
+
 
         [GlobalSetup]
         public void GlobalSetup()
         {
-            //code main entry 
-            _subj = new Paths64
-            {
-                ClipperFunc.MakePath(new int[] { 100, 50, 10, 79, 65, 2, 65, 98, 10, 21 })
-            };
-            _clip = new Paths64
-            {
-                ClipperFunc.MakePath(new int[] { 80, 50, 69, 73, 43, 79, 23, 63, 23, 37, 43, 21, 69, 27 })
-            };
-            _pathInflate = new Paths64
-            {
-                ClipperFunc.MakePath(new int[] { 93, 50, 77, 84, 40, 92, 11, 69, 11, 31, 40, 8, 77, 16 })
-            };
+            Random rand = new Random();
+
+            _subj = new Paths64();
+            _clip = new Paths64();
+            _solution = new Paths64();
+
+            _subj.Add(MakeRandomPath(DisplayWidth, DisplayHeight, EdgeCount, rand));
+            _clip.Add(MakeRandomPath(DisplayWidth, DisplayHeight, EdgeCount, rand));
         }
 
         [Benchmark]
-        public void Union_Null_Clip_EvenOdd()
+        public void Intersection_N()
         {
-            Paths64 solution1 = ClipperFunc.Union(_subj, null, FillRule.EvenOdd);
+            Clipper c = new Clipper();
+            c.AddSubject(_subj);
+            c.AddClip(_clip);
+            c.Execute(ClipType.Intersection, FillRule.NonZero, _solution);
         }
 
         [Benchmark]
-        public void Union_Null_Clip_NonZero()
+        public void Union_N()
         {
-            Paths64 solution2 = ClipperFunc.Union(_subj, null, FillRule.NonZero);
+            Clipper c = new Clipper();
+            c.AddSubject(_subj);
+            c.AddClip(_clip);
+            c.Execute(ClipType.Union, FillRule.NonZero, _solution);
         }
 
         [Benchmark]
-        public void Union_Clip_NonZero()
+        public void Difference_N()
         {
-            Paths64 solution3 = ClipperFunc.Union(_subj, _clip, FillRule.NonZero);
+            Clipper c = new Clipper();
+            c.AddSubject(_subj);
+            c.AddClip(_clip);
+            c.Execute(ClipType.Difference, FillRule.NonZero, _solution);
         }
 
         [Benchmark]
-        public void Intersect_Clip_NonZero()
+        public void Xor_N()
         {
-            Paths64 solution4 = ClipperFunc.Intersect(_subj, _clip, FillRule.NonZero);
+            Clipper c = new Clipper();
+            c.AddSubject(_subj);
+            c.AddClip(_clip);
+            c.Execute(ClipType.Xor, FillRule.NonZero, _solution);
+        }
+        private static Point64 MakeRandomPt(int maxWidth, int maxHeight, Random rand)
+        {
+            long x = rand.Next(maxWidth);
+            var y = rand.Next(maxHeight);
+            return new Point64(x, y);
         }
 
-        [Benchmark]
-        public void Intersect_Clip_EvenOdd()
+        public static Path64 MakeRandomPath(int width, int height, int count, Random rand)
         {
-            Paths64 solution5 = ClipperFunc.Intersect(_subj, _clip, FillRule.EvenOdd);
-        }
-
-        [Benchmark]
-        public void InflatePaths_Delta5()
-        {
-            Paths64 solution6 = ClipperFunc.InflatePaths(_pathInflate, 5.0, JoinType.Miter, EndType.Polygon);
-        }
-
-
-        [Benchmark]
-        public void InflatePaths_DeltaMinus5()
-        {
-            Paths64 solution7 = ClipperFunc.InflatePaths(_pathInflate, -5.0, JoinType.Miter, EndType.Polygon);
-        }
-
-        [Benchmark]
-        public void InflatePaths_Delta10()
-        {
-            Paths64 solution8 = ClipperFunc.InflatePaths(_pathInflate, 10.0, JoinType.Miter, EndType.Square);
-        }
-
-        [Benchmark]
-        public void InflatePaths_DeltaMinus10()
-        {
-            Paths64 solution9 = ClipperFunc.InflatePaths(_pathInflate, 10.0, JoinType.Miter, EndType.Joined);
+            Path64 result = new Path64(count);
+            for (int i = 0; i < count; ++i)
+                result.Add(MakeRandomPt(width, height, rand));
+            return result;
         }
     }
 }

--- a/CSharp/Clipper2Lib.sln
+++ b/CSharp/Clipper2Lib.sln
@@ -3,11 +3,16 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Clipper2Lib", "Clipper2Lib\Clipper2Lib.csproj", "{4CE00B81-F1B2-4012-9BBD-B0DB6BF8CAD3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Clipper2Lib", "Clipper2Lib\Clipper2Lib.csproj", "{4CE00B81-F1B2-4012-9BBD-B0DB6BF8CAD3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Clipper2Lib.Benchmark", "Clipper2Lib.Benchmark\Clipper2Lib.Benchmark.csproj", "{F8A168C6-286A-4ECF-8750-C505ADBCB7D5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Clipper2LibExample", "Clipper2LibExample\Clipper2LibExample.csproj", "{4BA8DEFE-0678-4C41-9B16-3A4639DFB838}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Clipper2LibExample", "Clipper2LibExample\Clipper2LibExample.csproj", "{4BA8DEFE-0678-4C41-9B16-3A4639DFB838}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{67AA6FC2-5AC3-4220-8860-A99BDDA6F5EC}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/CSharp/Clipper2Lib/Clipper.Core.cs
+++ b/CSharp/Clipper2Lib/Clipper.Core.cs
@@ -59,39 +59,39 @@ namespace Clipper2Lib
         }
 
 #else
-    public Point64(Point64 pt)
-    {
-      this.X = pt.X;
-      this.Y = pt.Y;
-    }
+        public Point64(Point64 pt)
+        {
+            this.X = pt.X;
+            this.Y = pt.Y;
+        }
 
-    public Point64(long x, long y)
-    {
-      this.X = x;
-      this.Y = y;
-    }
+        public Point64(long x, long y)
+        {
+            this.X = x;
+            this.Y = y;
+        }
 
-    public Point64(double x, double y)
-    {
-      this.X = (long)Math.Round(x);
-      this.Y = (long)Math.Round(y);
-    }
+        public Point64(double x, double y)
+        {
+            this.X = (long) Math.Round(x);
+            this.Y = (long) Math.Round(y);
+        }
 
-    public Point64(PointD pt)
-    {
-      this.X = (long)Math.Round(pt.x);
-      this.Y = (long)Math.Round(pt.y);
-    }
+        public Point64(PointD pt)
+        {
+            this.X = (long) Math.Round(pt.x);
+            this.Y = (long) Math.Round(pt.y);
+        }
 
-    public static bool operator ==(Point64 lhs, Point64 rhs)
-    {
-      return lhs.X == rhs.X && lhs.Y == rhs.Y;
-    }
+        public static bool operator ==(Point64 lhs, Point64 rhs)
+        {
+            return lhs.X == rhs.X && lhs.Y == rhs.Y;
+        }
 
-    public static bool operator !=(Point64 lhs, Point64 rhs)
-    {
-      return lhs.X != rhs.X || lhs.Y != rhs.Y;
-    }
+        public static bool operator !=(Point64 lhs, Point64 rhs)
+        {
+            return lhs.X != rhs.X || lhs.Y != rhs.Y;
+        }
 
 #endif
         public override bool Equals(object obj)
@@ -147,29 +147,29 @@ namespace Clipper2Lib
         }
 
 #else
-    public PointD(PointD pt)
-    {
-      this.x = pt.x;
-      this.y = pt.y;
-    }
+        public PointD(PointD pt)
+        {
+            this.x = pt.x;
+            this.y = pt.y;
+        }
 
-    public PointD(Point64 pt)
-    {
-      this.x = pt.X;
-      this.y = pt.Y;
-    }
+        public PointD(Point64 pt)
+        {
+            this.x = pt.X;
+            this.y = pt.Y;
+        }
 
-    public PointD(long x, long y)
-    {
-      this.x = x;
-      this.y = y;
-    }
+        public PointD(long x, long y)
+        {
+            this.x = x;
+            this.y = y;
+        }
 
-    public PointD(double x, double y)
-    {
-      this.x = x;
-      this.y = y;
-    }
+        public PointD(double x, double y)
+        {
+            this.x = x;
+            this.y = y;
+        }
 
 #endif
 

--- a/CSharp/Clipper2Lib/Clipper.Engine.cs
+++ b/CSharp/Clipper2Lib/Clipper.Engine.cs
@@ -18,8 +18,8 @@ using System.Runtime.CompilerServices;
 namespace Clipper2Lib
 {
     using Path64 = List<Point64>;
-    using Paths64 = List<List<Point64>>;
     using PathD = List<PointD>;
+    using Paths64 = List<List<Point64>>;
     using PathsD = List<List<PointD>>;
 
     //Vertex: a pre-clipping data structure. It is used to separate polygons
@@ -70,9 +70,9 @@ namespace Clipper2Lib
     //Y coordinates to the smallest while keeping edges adjacent.
     internal struct IntersectNode
     {
-      public readonly Point64 pt;
-      public readonly Active edge1;
-      public readonly Active edge2;
+        public readonly Point64 pt;
+        public readonly Active edge1;
+        public readonly Active edge2;
 
         public IntersectNode(Point64 pt, Active edge1, Active edge2)
         {
@@ -113,11 +113,11 @@ namespace Clipper2Lib
     internal class OutRec
     {
         public int idx;
-        public OutRec owner;
-        public Active frontEdge;
-        public Active backEdge;
-        public OutPt pts;
-        public PolyPathBase polypath;
+        public OutRec? owner;
+        public Active? frontEdge;
+        public Active? backEdge;
+        public OutPt? pts;
+        public PolyPathBase? polypath;
         public OutRecState state;
     };
 
@@ -125,10 +125,10 @@ namespace Clipper2Lib
     internal class Joiner
     {
         public int idx;
-        public OutPt op1;
-        public OutPt op2;
-        public Joiner next1;
-        public Joiner next2;
+        public OutPt? op1;
+        public OutPt? op2;
+        public Joiner? next1;
+        public Joiner? next2;
     }
 
     internal class Active
@@ -141,23 +141,23 @@ namespace Clipper2Lib
         public int windCount;
         public int windCount2; //winding count of the opposite polytype
 
-        public OutRec outrec;
+        public OutRec? outrec;
 
         //AEL: 'active edge list' (Vatti's AET - active edge table)
         //     a linked list of all edges (from left to right) that are present
         //     (or 'active') within the current scanbeam (a horizontal 'beam' that
         //     sweeps from bottom to top over the paths in the clipping operation).
-        public Active prevInAEL;
+        public Active? prevInAEL;
 
-        public Active nextInAEL;
+        public Active? nextInAEL;
 
         //SEL: 'sorted edge list' (Vatti's ST - sorted table)
         //     linked list used when sorting edges into their new positions at the
         //     top of scanbeams, but also (re)used to process horizontals.
-        public Active prevInSEL;
-        public Active nextInSEL;
-        public Active jump;
-        public Vertex vertexTop;
+        public Active? prevInSEL;
+        public Active? nextInSEL;
+        public Active? jump;
+        public Vertex? vertexTop;
         public LocalMinima localMin; //the bottom of an edge 'bound' (also Vatti)
         internal bool leftBound;
     };
@@ -448,7 +448,7 @@ namespace Clipper2Lib
             return ((ae.vertexTop.flags & VertexFlags.LocalMax) != VertexFlags.None);
         }
 
-        private Active GetMaximaPair(Active ae)
+        private Active? GetMaximaPair(Active ae)
         {
             Active ae2;
             if (IsHorizontal(ae))
@@ -1578,7 +1578,7 @@ namespace Clipper2Lib
             }
         }
 
-        private OutPt IntersectEdges(Active ae1, Active ae2, Point64 pt)
+        private OutPt? IntersectEdges(Active ae1, Active ae2, Point64 pt)
         {
             OutPt resultOp = null;
             //MANAGE OPEN PATH INTERSECTIONS SEPARATELY ...
@@ -1839,7 +1839,7 @@ namespace Clipper2Lib
             _cliptype = ct;
             Reset();
             if (!PopScanline(out long y)) return;
-            for (;;)
+            for (; ; )
             {
                 InsertLocalMinimaIntoAEL(y);
                 Active ae;
@@ -1952,7 +1952,7 @@ namespace Clipper2Lib
                         if (right.curX < left.curX)
                         {
                             tmp = right.prevInSEL;
-                            for (;;)
+                            for (; ; )
                             {
                                 AddNewIntersectNode(tmp, right, topY);
                                 if (tmp == left) break;
@@ -2089,20 +2089,20 @@ namespace Clipper2Lib
         }
 
         private void DoHorizontal(Active horz)
-            /*******************************************************************************
-                * Notes: Horizontal edges (HEs) at scanline intersections (ie at the top or    *
-                * bottom of a scanbeam) are processed as if layered.The order in which HEs     *
-                * are processed doesn't matter. HEs intersect with the bottom vertices of      *
-                * other HEs[#] and with non-horizontal edges [*]. Once these intersections     *
-                * are completed, intermediate HEs are 'promoted' to the next edge in their     *
-                * bounds, and they in turn may be intersected[%] by other HEs.                 *
-                *                                                                              *
-                * eg: 3 horizontals at a scanline:    /   |                     /           /  *
-                *              |                     /    |     (HE3)o ========%========== o   *
-                *              o ======= o(HE2)     /     |         /         /                *
-                *          o ============#=========*======*========#=========o (HE1)           *
-                *         /              |        /       |       /                            *
-                *******************************************************************************/
+        /*******************************************************************************
+            * Notes: Horizontal edges (HEs) at scanline intersections (ie at the top or    *
+            * bottom of a scanbeam) are processed as if layered.The order in which HEs     *
+            * are processed doesn't matter. HEs intersect with the bottom vertices of      *
+            * other HEs[#] and with non-horizontal edges [*]. Once these intersections     *
+            * are completed, intermediate HEs are 'promoted' to the next edge in their     *
+            * bounds, and they in turn may be intersected[%] by other HEs.                 *
+            *                                                                              *
+            * eg: 3 horizontals at a scanline:    /   |                     /           /  *
+            *              |                     /    |     (HE3)o ========%========== o   *
+            *              o ======= o(HE2)     /     |         /         /                *
+            *          o ============#=========*======*========#=========o (HE1)           *
+            *         /              |        /       |       /                            *
+            *******************************************************************************/
         {
             Point64 pt;
             bool horzIsOpen = IsOpen(horz);
@@ -2130,7 +2130,7 @@ namespace Clipper2Lib
             }
 
             OutPt op;
-            for (;;)
+            for (; ; )
             {
                 //loops through consec. horizontal edges (if open)
                 Active ae;
@@ -2433,7 +2433,7 @@ namespace Clipper2Lib
             return op.nextHorz != null || op == _horzLast;
         }
 
-        private bool ValidateOrDeleteClosedPath(ref OutPt op)
+        private bool ValidateOrDeleteClosedPath(ref OutPt? op)
         {
             if (IsValidClosedPath(op)) return true;
             SafeDisposeOutPts(op);
@@ -2653,7 +2653,7 @@ namespace Clipper2Lib
             op2.joiner = j;
         }
 
-        private static Joiner FindJoinParent(Joiner parent, Joiner joiner)
+        private static Joiner? FindJoinParent(Joiner parent, Joiner joiner)
         {
             if (parent == null) return null;
             if (parent.next1 == joiner || parent.next2 == joiner) return parent;
@@ -2783,7 +2783,7 @@ namespace Clipper2Lib
                 if (op2.next == op1) return or1;
             }
 
-            for (;;)
+            for (; ; )
             {
                 if (!IsValidPath(op1) || !IsValidPath(op2)) return or1;
                 if (or1 == or2 && (op1.prev == op2 || op1.next == op2)) return or1;
@@ -2939,7 +2939,7 @@ namespace Clipper2Lib
         private static void UpdateOutrecOwner(OutRec outrec)
         {
             OutPt opCurr = outrec.pts;
-            for (;;)
+            for (; ; )
             {
                 opCurr.outrec = outrec;
                 opCurr = opCurr.next;
@@ -3009,11 +3009,11 @@ namespace Clipper2Lib
             FixSelfIntersects(ref outrec.pts);
         }
 
-        private void CleanCollinear(ref OutPt op)
+        private void CleanCollinear(ref OutPt? op)
         {
             if (!ValidateOrDeleteClosedPath(ref op)) return;
             OutPt startOp = op, op2 = op;
-            for (;;)
+            for (; ; )
             {
                 //nb: if preserveCollinear == true, then only remove 180 deg.spikes
                 if ((InternalClipperFunc.CrossProduct(op2.prev.pt, op2.pt, op2.next.pt) == 0) &&
@@ -3067,7 +3067,7 @@ namespace Clipper2Lib
             }
             else
             {
-                OutPt newOp2 = new OutPt(ip, prevOp.outrec) {prev = prevOp, next = nextNextOp};
+                OutPt newOp2 = new OutPt(ip, prevOp.outrec) { prev = prevOp, next = nextNextOp };
                 nextNextOp.prev = newOp2;
                 prevOp.next = newOp2;
             }
@@ -3087,7 +3087,7 @@ namespace Clipper2Lib
                 splitOp.outrec = newOutRec;
                 splitOp.next.outrec = newOutRec;
 
-                OutPt newOp = new OutPt(ip, newOutRec) {prev = splitOp.next, next = splitOp};
+                OutPt newOp = new OutPt(ip, newOutRec) { prev = splitOp.next, next = splitOp };
                 newOutRec.pts = newOp;
                 splitOp.prev = newOp;
                 splitOp.next.next = newOp;
@@ -3100,7 +3100,7 @@ namespace Clipper2Lib
         {
             if (!IsValidClosedPath(op)) return;
             OutPt op2 = op;
-            for (;;)
+            for (; ; )
             {
                 //3 edged polygons can't self-intersect
                 if (op2.prev == op2.next.next) break;
@@ -3513,7 +3513,7 @@ namespace Clipper2Lib
             get => GetIsHole();
         }
 
-        public PolyPathBase(PolyPathBase parent = null)
+        public PolyPathBase(PolyPathBase? parent = null)
         {
             _parent = parent;
         }
@@ -3538,7 +3538,7 @@ namespace Clipper2Lib
 
         internal abstract PolyPathBase AddChild(Path64 p);
 
-        public PolyPathBase GetChild(int idx)
+        public PolyPathBase? GetChild(int idx)
         {
             if (idx < 0 || idx >= ChildCount) return null;
             else return _childs[idx];
@@ -3554,7 +3554,7 @@ namespace Clipper2Lib
     {
         public Path64 Polygon { get; private set; }
 
-        public PolyPath(PolyPathBase parent = null) : base(parent)
+        public PolyPath(PolyPathBase? parent = null) : base(parent)
         {
         }
 
@@ -3572,7 +3572,7 @@ namespace Clipper2Lib
         internal double Scale { get; set; }
         public PathD Polygon { get; private set; }
 
-        public PolyPathD(PolyPathBase parent = null) : base(parent)
+        public PolyPathD(PolyPathBase? parent = null) : base(parent)
         {
         }
 

--- a/CSharp/Clipper2Lib/Clipper.Offset.cs
+++ b/CSharp/Clipper2Lib/Clipper.Offset.cs
@@ -15,8 +15,8 @@ using System.Runtime.CompilerServices;
 namespace Clipper2Lib
 {
     using Path64 = List<Point64>;
-    using Paths64 = List<List<Point64>>;
     using PathD = List<PointD>;
+    using Paths64 = List<List<Point64>>;
     using PathsD = List<List<PointD>>;
 
     public enum JoinType
@@ -89,7 +89,7 @@ namespace Clipper2Lib
         {
             int cnt = path.Count;
             if (cnt == 0) return;
-            PathsD pp = new PathsD(1) { ClipperFunc.PathD(path)};
+            PathsD pp = new PathsD(1) { ClipperFunc.PathD(path) };
             AddPaths(pp, joinType, endType);
         }
 
@@ -122,8 +122,8 @@ namespace Clipper2Lib
             if (Math.Abs(delta) < _minLenSqrd)
             {
                 foreach (PathGroup group in _pathGroups)
-                  foreach (PathD path in group._inPaths)
-                      solution.Add(path);
+                    foreach (PathD path in group._inPaths)
+                        solution.Add(path);
                 return solution;
             }
 

--- a/CSharp/Clipper2Lib/Clipper.SVG.cs
+++ b/CSharp/Clipper2Lib/Clipper.SVG.cs
@@ -10,270 +10,274 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Globalization;
+using System.IO;
 
 namespace Clipper2Lib
 {
 
-  using Paths64 = List<List<Point64>>;
-  using PathD = List<PointD>;
-  using PathsD = List<List<PointD>>;
+    using PathD = List<PointD>;
+    using Paths64 = List<List<Point64>>;
+    using PathsD = List<List<PointD>>;
 
     public class SimpleClipperSvgWriter
-  {
-
-    public const uint black = 0xFF000000;
-    public const uint white = 0xFFFFFFFF;
-    public const uint maroon = 0xFF800000;
-
-    public const uint navy = 0xFF000080;
-    public const uint blue = 0xFF0000FF;
-    public const uint red = 0xFFFF0000;
-    public const uint green = 0xFF008000;
-    public const uint yellow = 0xFFFFFF00;
-    public const uint lime = 0xFF00FF00;
-    public const uint fuscia = 0xFFFF00FF;
-    public const uint aqua = 0xFF00FFFF;
-
-    public static RectD RectMax = 
-      new RectD(double.MaxValue, double.MaxValue, -double.MaxValue, -double.MaxValue);
-    public static RectD RectEmpty = new RectD(0, 0, 0, 0);
-
-    internal static bool IsValidRect(RectD rec)
     {
-      return rec.right >= rec.left && rec.bottom >= rec.top;
-    }
 
-    private readonly struct CoordStyle
-    {
-      public readonly string FontName;
-      public readonly int FontSize;
-      public readonly uint FontColor;
-      public CoordStyle(string fontname, int fontsize, uint fontcolor) 
-      {
-        FontName = fontname;
-        FontSize = fontsize;
-        FontColor = fontcolor;
-      }
-    }
+        public const uint black = 0xFF000000;
+        public const uint white = 0xFFFFFFFF;
+        public const uint maroon = 0xFF800000;
 
-    private readonly struct TextInfo
-    {
-      public readonly string text;
-      public readonly int fontSize;
-      public readonly uint fontColor;
-      public readonly int posX;
-      public readonly int posY;
-      public TextInfo(string text, int x, int y, 
-        int fontsize = 12, uint fontcolor = black) 
-      {
-        this.text = text;
-        posX = x;
-        posY = y;
-        fontSize = fontsize;
-        fontColor = fontcolor;
-      }
-    }
+        public const uint navy = 0xFF000080;
+        public const uint blue = 0xFF0000FF;
+        public const uint red = 0xFFFF0000;
+        public const uint green = 0xFF008000;
+        public const uint yellow = 0xFFFFFF00;
+        public const uint lime = 0xFF00FF00;
+        public const uint fuscia = 0xFFFF00FF;
+        public const uint aqua = 0xFF00FFFF;
 
-    private readonly struct PolyInfo
-    {
-      public readonly PathsD paths;
-      public readonly uint BrushClr;
-      public readonly uint PenClr;
-      public readonly double PenWidth;
-      public readonly bool ShowCoords;
-      public readonly bool IsOpen;
-      public PolyInfo(PathsD paths, uint brushcolor, uint pencolor, 
-        double penwidth, bool showcoords = false, bool isopen = false) 
-      {
-        this.paths = new PathsD(paths);
-        BrushClr = brushcolor;
-        PenClr = pencolor;
-        PenWidth = penwidth;
-        ShowCoords = showcoords;
-        IsOpen = isopen;
-      }
-    }
+        public static RectD RectMax =
+          new RectD(double.MaxValue, double.MaxValue, -double.MaxValue, -double.MaxValue);
+        public static RectD RectEmpty = new RectD(0, 0, 0, 0);
 
-    public FillRule FillRule { get; set; }
-    private readonly List<PolyInfo> PolyInfoList = new List<PolyInfo>();
-    private readonly List<TextInfo> textInfos = new List<TextInfo>();
-    private readonly CoordStyle coordStyle;
-
-    private const string svg_header = "<?xml version=\"1.0\" standalone=\"no\"?>\n" +
-      "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.0//EN\"\n" +
-      "\"http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd\">\n\n" +
-      "<svg width=\"{0}px\" height=\"{1}px\" viewBox=\"0 0 {0} {1}\"" +
-      " version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\">\n\n";
-    private const string svg_path_format = "\"\n style=\"fill:{0};" +
-        " fill-opacity:{1:f2}; fill-rule:{2}; stroke:{3};" +
-        " stroke-opacity:{4:f2}; stroke-width:{5:f2};\"/>\n\n";
-    private const string svg_path_format2 = "\"\n style=\"fill:none; stroke:{0};" +
-        "stroke-opacity:{1:f2}; stroke-width:{2:f2};\"/>\n\n";
-
-    public SimpleClipperSvgWriter(FillRule fillrule, 
-      string coordFontName = "Verdana", int coordFontsize = 9, uint coordFontColor = black)
-    {
-      coordStyle = new CoordStyle(coordFontName, coordFontsize, coordFontColor);
-      FillRule = fillrule;
-    }
-
-    public void ClearPaths()
-    {
-      PolyInfoList.Clear();
-    }
-
-    public void ClearText()
-    {
-      textInfos.Clear();
-    }
-
-    public void ClearAll()
-    {
-      PolyInfoList.Clear();
-      textInfos.Clear();
-    }
-
-
-    public void AddPaths(Paths64 paths, bool IsOpen, uint brushColor,
-      uint penColor, double penWidth, bool showCoords = false)
-    {
-      if (paths.Count == 0) return;
-      PolyInfoList.Add(new PolyInfo(ClipperFunc.PathsD(paths), 
-        brushColor, penColor, penWidth, showCoords, IsOpen));
-    }
-    //------------------------------------------------------------------------------
-
-    public void AddPaths(PathsD paths, bool IsOpen, uint brushColor,
-      uint penColor, double penWidth, bool showCoords = false)
-    {
-      if (paths.Count == 0) return;
-      PolyInfoList.Add(new PolyInfo(paths,
-        brushColor, penColor, penWidth, showCoords, IsOpen));
-    }
-
-    public void AddText(string cap, int posX, int posY, int fontSize, uint fontClr)
-    {
-      textInfos.Add(new TextInfo(cap, posX, posY, fontSize, fontClr));
-    }
-
-    private RectD GetBounds()
-    {
-      RectD bounds = new RectD(RectMax);
-      foreach (PolyInfo pi in PolyInfoList)
-        foreach (PathD path in pi.paths)
-          foreach (PointD pt in path) {
-            if (pt.x < bounds.left) bounds.left = pt.x;
-            if (pt.x > bounds.right) bounds.right = pt.x;
-            if (pt.y < bounds.top) bounds.top = pt.y;
-            if (pt.y > bounds.bottom) bounds.bottom = pt.y;
-          }
-      if (!IsValidRect(bounds))
-        return RectEmpty;
-      else
-        return bounds;
-    }
-
-    private static string ColorToHtml(uint clr)
-    {
-      return '#' + (clr & 0xFFFFFF).ToString("X6");
-    }
-
-    private static float GetAlpha(uint clr)
-    {
-      return ((float)(clr >> 24) / 255);
-    }
-
-    public bool SaveToFile(string filename, int maxWidth = 0, int maxHeight = 0, int margin = 20)
-    {
-      if (margin < 20) margin = 20;
-      RectD bounds = GetBounds();
-      if (bounds.IsEmpty()) return false;
-
-      double scale = 1.0;
-      if (maxWidth > 0 && maxHeight > 0)
-        scale = 1.0 / Math.Max((double)(bounds.right - bounds.left) / (maxWidth - margin * 2),
-          (double)(bounds.bottom - bounds.top) / (maxHeight - margin * 2));
-
-      long offsetX = margin - (long)(bounds.left * scale);
-      long offsetY = margin - (long)(bounds.top * scale);
-
-      StreamWriter writer = new StreamWriter(filename);
-      if (writer == null) return false;
-
-      if (maxWidth <= 0 || maxHeight <= 0) 
-        writer.Write(svg_header, (bounds.right - bounds.left) + margin * 2,
-          (bounds.bottom - bounds.top) + margin * 2);
-      else
-        writer.Write(svg_header, maxWidth, maxHeight);
-
-      foreach (PolyInfo pi in PolyInfoList)
-      {
-        writer.Write(" <path d=\"");
-        foreach (PathD path in pi.paths) 
+        internal static bool IsValidRect(RectD rec)
         {
-          if (path.Count < 2) continue;
-          if (!pi.IsOpen && path.Count < 3) continue;
-          writer.Write(string.Format(NumberFormatInfo.InvariantInfo, " M {0:f2} {1:f2}",
-              (path[0].x * scale + offsetX),
-              (path[0].y * scale + offsetY)));
-          for (int j = 1; j < path.Count; j++) 
-          { 
-            writer.Write(string.Format(NumberFormatInfo.InvariantInfo, " L {0:f2} {1:f2}",
-            (path[j].x * scale + offsetX),
-            (path[j].y * scale + offsetY)));
-          }
-          if (!pi.IsOpen) writer.Write(" z");
+            return rec.right >= rec.left && rec.bottom >= rec.top;
         }
 
-        if (!pi.IsOpen)
-          writer.Write(string.Format(NumberFormatInfo.InvariantInfo, svg_path_format,
-              ColorToHtml(pi.BrushClr), GetAlpha(pi.BrushClr),
-              (FillRule == FillRule.EvenOdd ? "evenodd" : "nonzero"),
-              ColorToHtml(pi.PenClr), GetAlpha(pi.PenClr), pi.PenWidth));
-        else
-          writer.Write(string.Format(NumberFormatInfo.InvariantInfo, svg_path_format2,
-              ColorToHtml(pi.PenClr), GetAlpha(pi.PenClr), pi.PenWidth));
+        private readonly struct CoordStyle
+        {
+            public readonly string FontName;
+            public readonly int FontSize;
+            public readonly uint FontColor;
+            public CoordStyle(string fontname, int fontsize, uint fontcolor)
+            {
+                FontName = fontname;
+                FontSize = fontsize;
+                FontColor = fontcolor;
+            }
+        }
 
-        if (pi.ShowCoords) {
-          writer.Write(string.Format("<g font-family=\"{0}\" font-size=\"{1}\" fill=\"{2}\">\n\n",
-            coordStyle.FontName, coordStyle.FontSize, ColorToHtml(coordStyle.FontColor)));
-          foreach (PathD path in pi.paths) {
-            foreach (PointD pt in path) {
+        private readonly struct TextInfo
+        {
+            public readonly string text;
+            public readonly int fontSize;
+            public readonly uint fontColor;
+            public readonly int posX;
+            public readonly int posY;
+            public TextInfo(string text, int x, int y,
+              int fontsize = 12, uint fontcolor = black)
+            {
+                this.text = text;
+                posX = x;
+                posY = y;
+                fontSize = fontsize;
+                fontColor = fontcolor;
+            }
+        }
+
+        private readonly struct PolyInfo
+        {
+            public readonly PathsD paths;
+            public readonly uint BrushClr;
+            public readonly uint PenClr;
+            public readonly double PenWidth;
+            public readonly bool ShowCoords;
+            public readonly bool IsOpen;
+            public PolyInfo(PathsD paths, uint brushcolor, uint pencolor,
+              double penwidth, bool showcoords = false, bool isopen = false)
+            {
+                this.paths = new PathsD(paths);
+                BrushClr = brushcolor;
+                PenClr = pencolor;
+                PenWidth = penwidth;
+                ShowCoords = showcoords;
+                IsOpen = isopen;
+            }
+        }
+
+        public FillRule FillRule { get; set; }
+        private readonly List<PolyInfo> PolyInfoList = new List<PolyInfo>();
+        private readonly List<TextInfo> textInfos = new List<TextInfo>();
+        private readonly CoordStyle coordStyle;
+
+        private const string svg_header = "<?xml version=\"1.0\" standalone=\"no\"?>\n" +
+          "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.0//EN\"\n" +
+          "\"http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd\">\n\n" +
+          "<svg width=\"{0}px\" height=\"{1}px\" viewBox=\"0 0 {0} {1}\"" +
+          " version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\">\n\n";
+        private const string svg_path_format = "\"\n style=\"fill:{0};" +
+            " fill-opacity:{1:f2}; fill-rule:{2}; stroke:{3};" +
+            " stroke-opacity:{4:f2}; stroke-width:{5:f2};\"/>\n\n";
+        private const string svg_path_format2 = "\"\n style=\"fill:none; stroke:{0};" +
+            "stroke-opacity:{1:f2}; stroke-width:{2:f2};\"/>\n\n";
+
+        public SimpleClipperSvgWriter(FillRule fillrule,
+          string coordFontName = "Verdana", int coordFontsize = 9, uint coordFontColor = black)
+        {
+            coordStyle = new CoordStyle(coordFontName, coordFontsize, coordFontColor);
+            FillRule = fillrule;
+        }
+
+        public void ClearPaths()
+        {
+            PolyInfoList.Clear();
+        }
+
+        public void ClearText()
+        {
+            textInfos.Clear();
+        }
+
+        public void ClearAll()
+        {
+            PolyInfoList.Clear();
+            textInfos.Clear();
+        }
+
+
+        public void AddPaths(Paths64 paths, bool IsOpen, uint brushColor,
+          uint penColor, double penWidth, bool showCoords = false)
+        {
+            if (paths.Count == 0) return;
+            PolyInfoList.Add(new PolyInfo(ClipperFunc.PathsD(paths),
+              brushColor, penColor, penWidth, showCoords, IsOpen));
+        }
+        //------------------------------------------------------------------------------
+
+        public void AddPaths(PathsD paths, bool IsOpen, uint brushColor,
+          uint penColor, double penWidth, bool showCoords = false)
+        {
+            if (paths.Count == 0) return;
+            PolyInfoList.Add(new PolyInfo(paths,
+              brushColor, penColor, penWidth, showCoords, IsOpen));
+        }
+
+        public void AddText(string cap, int posX, int posY, int fontSize, uint fontClr)
+        {
+            textInfos.Add(new TextInfo(cap, posX, posY, fontSize, fontClr));
+        }
+
+        private RectD GetBounds()
+        {
+            RectD bounds = new RectD(RectMax);
+            foreach (PolyInfo pi in PolyInfoList)
+                foreach (PathD path in pi.paths)
+                    foreach (PointD pt in path)
+                    {
+                        if (pt.x < bounds.left) bounds.left = pt.x;
+                        if (pt.x > bounds.right) bounds.right = pt.x;
+                        if (pt.y < bounds.top) bounds.top = pt.y;
+                        if (pt.y > bounds.bottom) bounds.bottom = pt.y;
+                    }
+            if (!IsValidRect(bounds))
+                return RectEmpty;
+            else
+                return bounds;
+        }
+
+        private static string ColorToHtml(uint clr)
+        {
+            return '#' + (clr & 0xFFFFFF).ToString("X6");
+        }
+
+        private static float GetAlpha(uint clr)
+        {
+            return ((float) (clr >> 24) / 255);
+        }
+
+        public bool SaveToFile(string filename, int maxWidth = 0, int maxHeight = 0, int margin = 20)
+        {
+            if (margin < 20) margin = 20;
+            RectD bounds = GetBounds();
+            if (bounds.IsEmpty()) return false;
+
+            double scale = 1.0;
+            if (maxWidth > 0 && maxHeight > 0)
+                scale = 1.0 / Math.Max((double) (bounds.right - bounds.left) / (maxWidth - margin * 2),
+                  (double) (bounds.bottom - bounds.top) / (maxHeight - margin * 2));
+
+            long offsetX = margin - (long) (bounds.left * scale);
+            long offsetY = margin - (long) (bounds.top * scale);
+
+            StreamWriter writer = new StreamWriter(filename);
+            if (writer == null) return false;
+
+            if (maxWidth <= 0 || maxHeight <= 0)
+                writer.Write(svg_header, (bounds.right - bounds.left) + margin * 2,
+                  (bounds.bottom - bounds.top) + margin * 2);
+            else
+                writer.Write(svg_header, maxWidth, maxHeight);
+
+            foreach (PolyInfo pi in PolyInfoList)
+            {
+                writer.Write(" <path d=\"");
+                foreach (PathD path in pi.paths)
+                {
+                    if (path.Count < 2) continue;
+                    if (!pi.IsOpen && path.Count < 3) continue;
+                    writer.Write(string.Format(NumberFormatInfo.InvariantInfo, " M {0:f2} {1:f2}",
+                        (path[0].x * scale + offsetX),
+                        (path[0].y * scale + offsetY)));
+                    for (int j = 1; j < path.Count; j++)
+                    {
+                        writer.Write(string.Format(NumberFormatInfo.InvariantInfo, " L {0:f2} {1:f2}",
+                        (path[j].x * scale + offsetX),
+                        (path[j].y * scale + offsetY)));
+                    }
+                    if (!pi.IsOpen) writer.Write(" z");
+                }
+
+                if (!pi.IsOpen)
+                    writer.Write(string.Format(NumberFormatInfo.InvariantInfo, svg_path_format,
+                        ColorToHtml(pi.BrushClr), GetAlpha(pi.BrushClr),
+                        (FillRule == FillRule.EvenOdd ? "evenodd" : "nonzero"),
+                        ColorToHtml(pi.PenClr), GetAlpha(pi.PenClr), pi.PenWidth));
+                else
+                    writer.Write(string.Format(NumberFormatInfo.InvariantInfo, svg_path_format2,
+                        ColorToHtml(pi.PenClr), GetAlpha(pi.PenClr), pi.PenWidth));
+
+                if (pi.ShowCoords)
+                {
+                    writer.Write(string.Format("<g font-family=\"{0}\" font-size=\"{1}\" fill=\"{2}\">\n\n",
+                      coordStyle.FontName, coordStyle.FontSize, ColorToHtml(coordStyle.FontColor)));
+                    foreach (PathD path in pi.paths)
+                    {
+                        foreach (PointD pt in path)
+                        {
 #if USINGZ
               writer.Write(string.Format(
                   "<text x=\"{0}\" y=\"{1}\">{2},{3},{4}</text>\n",
                   (int)(pt.x * scale + offsetX), (int)(pt.y * scale + offsetY), pt.x, pt.y, pt.z));
 #else
-              writer.Write(string.Format(
-                  "<text x=\"{0}\" y=\"{1}\">{2},{3},{4}</text>\n",
-                  (int)(pt.x * scale + offsetX), (int)(pt.y * scale + offsetY), pt.x, pt.y));
+                            writer.Write(string.Format(
+                                "<text x=\"{0}\" y=\"{1}\">{2},{3},{4}</text>\n",
+                                (int) (pt.x * scale + offsetX), (int) (pt.y * scale + offsetY), pt.x, pt.y));
 #endif
+                        }
+                        writer.Write("\n");
+                    }
+                    writer.Write("</g>\n");
+                }
             }
-            writer.Write("\n");
-          }
-          writer.Write("</g>\n");
+
+            foreach (TextInfo captionInfo in textInfos)
+            {
+                writer.Write(string.Format(
+                    "<g font-family=\"Verdana\" font-style=\"normal\" " +
+                    "font-weight=\"normal\" font-size=\"{0}\" fill=\"{1}\">\n",
+                    captionInfo.fontSize, ColorToHtml(captionInfo.fontColor)));
+                writer.Write(string.Format(
+                    "<text x=\"{0}\" y=\"{1}\">{2}</text>\n</g>\n\n",
+                    (int) (captionInfo.posX * scale + margin),
+                    (int) (captionInfo.posY * scale + margin),
+                    captionInfo.text));
+            }
+
+            writer.Write("</svg>\n");
+            writer.Close();
+            return true;
         }
-      }
-
-      foreach (TextInfo captionInfo in textInfos)
-      {
-        writer.Write(string.Format(
-            "<g font-family=\"Verdana\" font-style=\"normal\" " +
-            "font-weight=\"normal\" font-size=\"{0}\" fill=\"{1}\">\n",
-            captionInfo.fontSize, ColorToHtml(captionInfo.fontColor)));
-        writer.Write(string.Format(
-            "<text x=\"{0}\" y=\"{1}\">{2}</text>\n</g>\n\n",
-            (int)(captionInfo.posX * scale + margin),
-            (int)(captionInfo.posY * scale + margin), 
-            captionInfo.text));
-      }
-
-      writer.Write("</svg>\n");
-      writer.Close();
-      return true;
     }
-  }
 
 }

--- a/CSharp/Clipper2Lib/Clipper.cs
+++ b/CSharp/Clipper2Lib/Clipper.cs
@@ -19,8 +19,8 @@ using System.Collections.Generic;
 namespace Clipper2Lib
 {
     using Path64 = List<Point64>;
-    using Paths64 = List<List<Point64>>;
     using PathD = List<PointD>;
+    using Paths64 = List<List<Point64>>;
     using PathsD = List<List<PointD>>;
 
     //PRE-COMPILER CONDITIONAL ...
@@ -68,7 +68,7 @@ namespace Clipper2Lib
             return BooleanOp(ClipType.Xor, fillRule, subject, clip);
         }
 
-        public static Paths64 BooleanOp(ClipType clipType, FillRule fillRule, Paths64 subject, Paths64 clip)
+        public static Paths64? BooleanOp(ClipType clipType, FillRule fillRule, Paths64 subject, Paths64 clip)
         {
             if (subject == null) return null;
             Paths64 solution = new Paths64();

--- a/CSharp/Clipper2Lib/Clipper2Lib.csproj
+++ b/CSharp/Clipper2Lib/Clipper2Lib.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <Nullable>enable</Nullable>
+	<LangVersion>latest</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/CSharp/Clipper2LibExample/Program.cs
+++ b/CSharp/Clipper2LibExample/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Clipper2Lib;
 using Path64 = System.Collections.Generic.List<Clipper2Lib.Point64>;
 using Paths64 = System.Collections.Generic.List<System.Collections.Generic.List<Clipper2Lib.Point64>>;

--- a/CSharp/Clipper2LibExample/Program.cs
+++ b/CSharp/Clipper2LibExample/Program.cs
@@ -11,13 +11,16 @@ namespace Clipper2LibExample
     {
         static void Main(string[] args)
         {
-            Stopwatch sw = Stopwatch.StartNew();
-            //code main entry 
-            Paths64 subj = new Paths64();
-            subj.Add(ClipperFunc.MakePath(new int[] { 100, 50, 10, 79, 65, 2, 65, 98, 10, 21 }));
-            Paths64 clip = new Paths64();
-            clip.Add(ClipperFunc.MakePath(new int[] { 80, 50, 69, 73, 43, 79, 23, 63, 23, 37, 43, 21, 69, 27 }));
-            /*Paths64 solution1 = ClipperFunc.Union(subj, null, FillRule.EvenOdd);
+            Paths64 subj = new Paths64
+            {
+                ClipperFunc.MakePath(new int[] { 100, 50, 10, 79, 65, 2, 65, 98, 10, 21 })
+            };
+            Paths64 clip = new Paths64
+            {
+                ClipperFunc.MakePath(new int[] { 80, 50, 69, 73, 43, 79, 23, 63, 23, 37, 43, 21, 69, 27 })
+            };
+
+            Paths64 solution1 = ClipperFunc.Union(subj, null, FillRule.EvenOdd);
             Paths64 solution2 = ClipperFunc.Union(subj, null, FillRule.NonZero);
             Paths64 solution3 = ClipperFunc.Union(subj, clip, FillRule.NonZero);
             Paths64 solution4 = ClipperFunc.Intersect(subj, clip, FillRule.NonZero);
@@ -27,12 +30,9 @@ namespace Clipper2LibExample
             subj.Add(ClipperFunc.MakePath(new int[] { 93, 50, 77, 84, 40, 92, 11, 69, 11, 31, 40, 8, 77, 16 }));
             Paths64 solution6 = ClipperFunc.InflatePaths(subj, 5.0, JoinType.Miter, EndType.Polygon);
             Paths64 solution7 = ClipperFunc.InflatePaths(subj, -5.0, JoinType.Miter, EndType.Polygon);
-            Paths64 solution8 = ClipperFunc.InflatePaths(subj, 10.0, JoinType.Miter, EndType.Square);*/
+            Paths64 solution8 = ClipperFunc.InflatePaths(subj, 10.0, JoinType.Miter, EndType.Square);
+            Paths64 solution9 = ClipperFunc.InflatePaths(subj, 10.0, JoinType.Miter, EndType.Joined);
 
-            while (sw.ElapsedMilliseconds < 10_000)
-            {
-                Paths64 solution9 = ClipperFunc.InflatePaths(subj, 10.0, JoinType.Miter, EndType.Joined);
-            }
         }
     }
 }


### PR DESCRIPTION
This PR adds a standard `.editorconfig` for the formatting which can be applied with the `dotnet format` command, and updates the benchmark for the performance calculations provided in issue #10.  This benchmark will be what I use moving forward for determining performance improvements.

If you want to run the benchmarks, they can be executed with the `dotnet run -project "CSharp/Clipper2Lib.Benchmark" -c Release` command from the project root directory.  It will generate a `BenchmarkDotNet.Artifacts` directory with the performance data.

Re-targeted .NET Standard for .NET framework compatibility and .NET 5.0 for Core.

### Performance 
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19044
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=6.0.201
  [Host]     : .NET Core 5.0.15 (CoreCLR 5.0.1522.11506, CoreFX 5.0.1522.11506), X64 RyuJIT
  DefaultJob : .NET Core 5.0.15 (CoreCLR 5.0.1522.11506, CoreFX 5.0.1522.11506), X64 RyuJIT


```
|         Method | EdgeCount |        Mean |     Error |    StdDev |     Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|--------------- |---------- |------------:|----------:|----------:|----------:|----------:|----------:|----------:|
| **Intersection_N** |      **1000** |   **113.85 ms** |  **0.586 ms** |  **0.519 ms** | **1000.0000** |  **400.0000** |  **200.0000** |   **8.23 MB** |
|        Union_N |      1000 |    93.09 ms |  0.286 ms |  0.253 ms |  166.6667 |         - |         - |   1.87 MB |
|   Difference_N |      1000 |    98.32 ms |  0.290 ms |  0.242 ms |  400.0000 |  200.0000 |         - |   3.48 MB |
|          Xor_N |      1000 |   113.80 ms |  0.581 ms |  0.544 ms | 1000.0000 |  400.0000 |  200.0000 |   8.57 MB |
| **Intersection_N** |      **2000** |   **531.70 ms** |  **2.407 ms** |  **2.252 ms** | **2000.0000** | **1000.0000** |         **-** |  **21.56 MB** |
|        Union_N |      2000 |   490.83 ms |  0.275 ms |  0.244 ms |         - |         - |         - |   3.07 MB |
|   Difference_N |      2000 |   485.13 ms |  0.856 ms |  0.801 ms | 1000.0000 |         - |         - |  10.75 MB |
|          Xor_N |      2000 |   515.65 ms |  0.544 ms |  0.482 ms | 1000.0000 |         - |         - |   16.1 MB |
| **Intersection_N** |      **3000** | **2,093.88 ms** |  **2.266 ms** |  **2.120 ms** | **3000.0000** | **1000.0000** |         **-** |  **30.37 MB** |
|        Union_N |      3000 | 2,042.23 ms |  2.684 ms |  2.511 ms |         - |         - |         - |    4.8 MB |
|   Difference_N |      3000 | 1,965.62 ms | 29.713 ms | 24.812 ms | 1000.0000 |         - |         - |  17.69 MB |
|          Xor_N |      3000 | 2,056.29 ms | 14.028 ms | 12.435 ms | 4000.0000 | 2000.0000 | 1000.0000 |  34.63 MB |
| **Intersection_N** |      **4000** | **6,218.49 ms** | **11.431 ms** | **10.692 ms** | **5000.0000** | **2000.0000** |         **-** |  **50.29 MB** |
|        Union_N |      4000 | 5,068.24 ms |  5.790 ms |  4.835 ms |         - |         - |         - |   7.52 MB |
|   Difference_N |      4000 | 5,503.27 ms |  9.499 ms |  8.885 ms | 3000.0000 | 2000.0000 | 1000.0000 |  27.98 MB |
|          Xor_N |      4000 | 5,691.87 ms | 10.220 ms |  9.559 ms | 6000.0000 | 3000.0000 | 1000.0000 |  47.75 MB |

