### PR TITLE
Fixed compilation of ConsoleDemo1

### DIFF
--- a/CPP/Examples/ConsoleDemo1/ConsoleDemo1.cpp
+++ b/CPP/Examples/ConsoleDemo1/ConsoleDemo1.cpp
@@ -8,8 +8,8 @@
 #include <conio.h>
 #include "windows.h"
 
-#include "..\Clipper2Lib\clipper.h"
-#include "..\clipper.svg.h"
+#include "../../Clipper2Lib/clipper.h"
+#include "../clipper.svg.h"
 
 using namespace std;
 using namespace Clipper2Lib;

--- a/CPP/Examples/ConsoleDemo1/ConsoleDemo1.vcxproj
+++ b/CPP/Examples/ConsoleDemo1/ConsoleDemo1.vcxproj
@@ -144,17 +144,14 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\Clipper2Lib\clipper.engine.cpp" />
-    <ClCompile Include="..\Clipper2Svg\clipper.svg.cpp" />
+    <ClCompile Include="..\..\Clipper2Lib\clipper.core.cpp" />
+    <ClCompile Include="..\..\Clipper2Lib\clipper.engine.cpp" />
+    <ClCompile Include="..\..\Clipper2Lib\clipper.offset.cpp" />
+    <ClCompile Include="..\clipper.svg.cpp" />
     <ClCompile Include="ConsoleDemo1.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
     </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="..\Clipper2Lib\clipper.core.h" />
-    <ClInclude Include="..\Clipper2Lib\clipper.engine.h" />
-    <ClInclude Include="..\Clipper2Svg\clipper.svg.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/CPP/Examples/clipper.svg.cpp
+++ b/CPP/Examples/clipper.svg.cpp
@@ -13,7 +13,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
-#include "./Clipper2Lib/clipper.h"
+#include "../Clipper2Lib/clipper.h"
 #include "clipper.svg.h"
 
 namespace Clipper2Lib {

--- a/CPP/Examples/clipper.svg.h
+++ b/CPP/Examples/clipper.svg.h
@@ -13,8 +13,8 @@
 #include <cstdlib>
 #include <string>
 
-#include ".\Clipper2Lib\clipper.engine.h"
-#include ".\Clipper2Lib\clipper.core.h"
+#include "../Clipper2Lib/clipper.engine.h"
+#include "../Clipper2Lib/clipper.core.h"
 
 namespace Clipper2Lib {
 


### PR DESCRIPTION
Fixed paths to includes and Clipper sources after the ConsoleDemo1
project was moved to Examples directory.
Replaced backlashes with forward slashes in C++ include paths.