### PR TITLE
Remove unused variable

### DIFF
--- a/CPP/Clipper2Lib/clipper.engine.cpp
+++ b/CPP/Clipper2Lib/clipper.engine.cpp
@@ -2364,7 +2364,6 @@ namespace Clipper2Lib {
 		int64_t y = horz.bot.y;
 		Vertex* vertex_max = nullptr;
 		Active* max_pair = nullptr;
-		bool isMax = false;
 
 		if (!horzIsOpen)
 		{


### PR DESCRIPTION
My Linux/gcc build has loads of compiler warnings enabled, so it's complaining about these kinds of things. (Wouldn't notice otherwise, of course.)