### PR TITLE
Fix something that looks like a result of excessive search & replace

### DIFF
--- a/CPP/Clipper2Lib/clipper.engine.cpp
+++ b/CPP/Clipper2Lib/clipper.engine.cpp
@@ -623,7 +623,7 @@ namespace Clipper2Lib {
 		//set owner ...
 		if (IsHeadingLeftHorz(e))
 		{
-			e2 = e.next_in_ael;  //ie assess state from opposite diRect64on
+			e2 = e.next_in_ael;  //ie assess state from opposite direction
 			while (e2 && (!IsHotEdge(*e2) || IsOpen(*e2)))
 				e2 = e2->next_in_ael;
 			if (!e2)
@@ -1006,12 +1006,12 @@ namespace Clipper2Lib {
 			//NB neither e2.WindCnt nor e2.WindDx should ever be 0.
 			if (e2->wind_cnt * e2->wind_dx < 0)
 			{
-				//opposite diRect64ons so 'e' is outside 'e2' ...
+				//opposite directions so 'e' is outside 'e2' ...
 				if (abs(e2->wind_cnt) > 1)
 				{
 					//outside prev poly but still inside another.
 					if (e2->wind_dx * e.wind_dx < 0)
-						//reversing diRect64on so use the same WC
+						//reversing direction so use the same WC
 						e.wind_cnt = e2->wind_cnt;
 					else
 						//otherwise keep 'reducing' the WC by 1 (ie towards 0) ...
@@ -1025,7 +1025,7 @@ namespace Clipper2Lib {
 			{
 				//'e' must be inside 'e2'
 				if (e2->wind_dx * e.wind_dx < 0)
-					//reversing diRect64on so use the same WC
+					//reversing direction so use the same WC
 					e.wind_cnt = e2->wind_cnt;
 				else
 					//otherwise keep 'increasing' the WC by 1 (ie away from 0) ...
@@ -2287,7 +2287,7 @@ namespace Clipper2Lib {
 	}
 
 
-	bool ClipperBase::ResetHorzDiRect64on(const Active& horz,
+	bool ClipperBase::ResetHorzDirection(const Active& horz,
 		const Active* max_pair, int64_t& horz_left, int64_t& horz_right)
 	{
 		if (horz.bot.x == horz.top.x)
@@ -2380,7 +2380,7 @@ namespace Clipper2Lib {
 
 		int64_t horz_left, horz_right;
 		bool is_left_to_right =
-			ResetHorzDiRect64on(horz, max_pair, horz_left, horz_right);
+			ResetHorzDirection(horz, max_pair, horz_left, horz_right);
 
 		if (IsHotEdge(horz))
 			AddOutPt(horz, Point64(horz.curr_x, y));
@@ -2503,7 +2503,7 @@ namespace Clipper2Lib {
 				TrimHorz(horz, true);
 
 			is_left_to_right = 
-				ResetHorzDiRect64on(horz, max_pair, horz_left, horz_right);
+				ResetHorzDirection(horz, max_pair, horz_left, horz_right);
 		}
 
 		if (IsHotEdge(horz))

--- a/CPP/Clipper2Lib/clipper.engine.h
+++ b/CPP/Clipper2Lib/clipper.engine.h
@@ -100,7 +100,7 @@ namespace Clipper2Lib {
 		Point64 top;
 		int64_t curr_x = 0;		//current (updated at every new scanline)
 		double dx = 0.0;
-		int wind_dx = 1;			//1 or -1 depending on winding diRect64on
+		int wind_dx = 1;			//1 or -1 depending on winding direction
 		int wind_cnt = 0;
 		int wind_cnt2 = 0;		//winding count of the opposite polytype
 		OutRec* outrec = nullptr;
@@ -189,7 +189,7 @@ namespace Clipper2Lib {
 			const Point64& pt, bool is_new = false);
 		OutPt* AddLocalMaxPoly(Active &e1, Active &e2, const Point64& pt);
 		void DoHorizontal(Active &horz);
-		bool ResetHorzDiRect64on(const Active &horz, const Active *max_pair,
+		bool ResetHorzDirection(const Active &horz, const Active *max_pair,
 			int64_t &horz_left, int64_t &horz_right);
 		void DoTopOfScanbeam(const int64_t top_y);
 		Active *DoMaxima(Active &e);


### PR DESCRIPTION
Perhaps case insensitive `RectI` -> `Rect64`?