### PR TITLE
Unnecessary conversion

### DIFF
--- a/CSharp/Clipper2Lib/Clipper.Offset.cs
+++ b/CSharp/Clipper2Lib/Clipper.Offset.cs
@@ -84,7 +84,7 @@ namespace Clipper2Lib
     {
       int cnt = path.Count;
       if (cnt == 0) return;
-      PathsD pp = new PathsD(1) { ClipperFunc.PathD(path) };
+      Paths64 pp = new Paths64(1) { path };
       AddPaths(pp, joinType, endType);
     }
 


### PR DESCRIPTION
Here AddPath(Path64) converts to PathD and calls AddPaths(PathsD), which converts to Paths64 when adding to _pathGroups.

This change makes it so AddPath(Path64) goes to AddPaths(Paths64), avoiding the conversion to Double and back to int.