### PR TITLE
Prevent offset stripping collinear points

### DIFF
--- a/CSharp/Clipper2Lib/Clipper.Offset.cs
+++ b/CSharp/Clipper2Lib/Clipper.Offset.cs
@@ -134,7 +134,7 @@ namespace Clipper2Lib
       if (MergeGroups && _pathGroups.Count > 0)
       {
         //clean up self-intersections ...
-        Clipper c = new Clipper() { PreserveCollinear = false };
+        Clipper c = new Clipper() { PreserveCollinear = true };
         c.AddSubject(solution);
         if (_pathGroups[0]._pathsReversed)
           c.Execute(ClipType.Union, FillRule.Negative, solution);
@@ -452,7 +452,7 @@ namespace Clipper2Lib
       if (!MergeGroups)
       {
         //clean up self-intersections ...
-        Clipper c = new Clipper() { PreserveCollinear = false };
+        Clipper c = new Clipper() { PreserveCollinear = true };
         c.AddSubject(group._outPaths);
         if (group._pathsReversed)
           c.Execute(ClipType.Union, FillRule.Negative, group._outPaths);


### PR DESCRIPTION
Offset used to retain these points, and there are use cases where retaining the points is helpful (e.g. for sliver/gap removal). It's not always possible to re-fragment the edges in a consistent manner.
Ideally, this behavior would be configurable.