### PR TITLE
Prevent copying but allow moving `PolyPath` objects

### DIFF
--- a/CPP/Clipper2Lib/clipper.engine.h
+++ b/CPP/Clipper2Lib/clipper.engine.h
@@ -270,6 +270,9 @@ namespace Clipper2Lib {
 
 		virtual ~PolyPath() { Clear(); };
 
+		PolyPath(const PolyPath&) = delete;
+		PolyPath& operator=(const PolyPath& other) = delete;
+
 		void Clear() { 
 			for (PolyPath<T>* child : childs) delete child;
 			childs.resize(0); 

--- a/CPP/Clipper2Lib/clipper.engine.h
+++ b/CPP/Clipper2Lib/clipper.engine.h
@@ -273,6 +273,9 @@ namespace Clipper2Lib {
 		PolyPath(const PolyPath&) = delete;
 		PolyPath& operator=(const PolyPath& other) = delete;
 
+		PolyPath(PolyPath&&) = default;
+		PolyPath& operator=(PolyPath&& other) = default;
+
 		void Clear() { 
 			for (PolyPath<T>* child : childs) delete child;
 			childs.resize(0); 


### PR DESCRIPTION
I was trying to return `PolyPath` objects from a function, and ran into problems, because the pointed-to memory was freed twice.

This pull request simply fixes a [rule of three](https://en.cppreference.com/w/cpp/language/rule_of_three) (or five) issue in the `PolyPath` class, preventing users from shooting themselves in the foot.