### PR TITLE
Fix compiler warning

### DIFF
--- a/CPP/Clipper2Lib/clipper.engine.h
+++ b/CPP/Clipper2Lib/clipper.engine.h
@@ -85,7 +85,7 @@ namespace Clipper2Lib {
 	using PolyTree64 = PolyPath<int64_t>;
 	using PolyTreeD = PolyPath<double>;
 
-	class OutRec;
+	struct OutRec;
 	typedef std::vector<OutRec*> OutRecList;
 
 	//OutRec: contains a path in the clipping solution. Edges in the AEL will


### PR DESCRIPTION
Problem: `warning C4099: 'Clipper2Lib::OutRec': type name first seen using 'struct' now seen using 'class'`

Solution: use `struct` even in the forward declaration