### PR TITLE
Add test that checks the orientation of paths after offsetting

### DIFF
--- a/CPP/Tests/Tests/TestOffset.cpp
+++ b/CPP/Tests/Tests/TestOffset.cpp
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+#include "../../Clipper2Lib/clipper.offset.h"
+
+TEST(Clipper2Tests, TestOrientationAfterOffsetting) {
+    Clipper2Lib::ClipperOffset clipper;
+
+    const Clipper2Lib::Path64 input = {
+        Clipper2Lib::Point64(0, 0),
+        Clipper2Lib::Point64(0, 5),
+        Clipper2Lib::Point64(5, 5),
+        Clipper2Lib::Point64(5, 0)
+    };
+
+    clipper.AddPath(input, Clipper2Lib::JoinType::Round, Clipper2Lib::EndType::Polygon);
+
+    const auto outputs = clipper.Execute(1);
+
+    ASSERT_EQ(outputs.size(), 1);
+
+    const auto& output = outputs.front();
+
+    EXPECT_EQ(Clipper2Lib::IsClockwise(input), Clipper2Lib::IsClockwise(output));
+}

--- a/CPP/Tests/VisualStudio/Tests.vcxproj
+++ b/CPP/Tests/VisualStudio/Tests.vcxproj
@@ -141,6 +141,7 @@
     <ClCompile Include="..\Tests\TestFromTextFile2.cpp" />
     <ClCompile Include="..\Tests\TestFromTextFile3.cpp" />
     <ClCompile Include="..\Tests\TestIntersection.cpp" />
+    <ClCompile Include="..\Tests\TestOffset.cpp" />
     <ClCompile Include="..\Tests\TestUnion.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/CPP/Tests/VisualStudio/Tests.vcxproj.filters
+++ b/CPP/Tests/VisualStudio/Tests.vcxproj.filters
@@ -31,6 +31,9 @@
     <ClCompile Include="..\Tests\TestFromTextFile3.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\TestOffset.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Tests">


### PR DESCRIPTION
I noticed that after the latest updates, the orientation of paths tends to change when offsetting.

For me this is not really a problem, as long as I know it, but thought it might be nice to have the orientation preserved?