### PR TITLE
Add example task that has become much slower with the latest version

### DIFF
--- a/CPP/Tests/Tests/TestFromTextFile2.cpp
+++ b/CPP/Tests/Tests/TestFromTextFile2.cpp
@@ -2,6 +2,10 @@
 #include "../../Clipper2Lib/clipper.h"
 #include "../../Utils/ClipFileLoad.h"
 
+#ifdef _WIN32
+#include <Windows.h> // for IsDebuggerPresent()
+#endif // _WIN32
+
 TEST(Clipper2Tests, TestFromTextFile2) {
     std::ifstream ifs("../../../Tests/Tests2.txt");
     ASSERT_TRUE(ifs);
@@ -23,8 +27,25 @@ TEST(Clipper2Tests, TestFromTextFile2) {
             c.AddSubject(subject);
             c.AddOpenSubject(subject_open);
             c.AddClip(clip);
+
+            const auto t0 = std::chrono::steady_clock::now();
+
             c.Execute(ct, fr, solution, solution_open);
+
+            const auto t1 = std::chrono::steady_clock::now();
+            const auto seconds_elapsed = std::chrono::duration_cast<std::chrono::seconds>(t1 - t0).count();
+
+#ifdef _WIN32
+#ifdef NDEBUG
+            if (!IsDebuggerPresent())
+            {
+                EXPECT_LT(seconds_elapsed, 60);
+            }
+#endif // NDEBUG
+#endif // _WIN32
+
             // For the time being at least, there are no test criteria here for the results.
+
             success = true;
         }
         EXPECT_TRUE(success);

--- a/CPP/Tests/Tests/TestFromTextFile2.cpp
+++ b/CPP/Tests/Tests/TestFromTextFile2.cpp
@@ -8,12 +8,13 @@ TEST(Clipper2Tests, TestFromTextFile2) {
     ASSERT_TRUE(ifs.good());
         
     Clipper2Lib::Paths64 subject, subject_open, clip;
-    Clipper2Lib::Paths64 solution, solution_open;
+    Clipper2Lib::PolyTree64 solution;
+    Clipper2Lib::Paths64 solution_open;
     Clipper2Lib::ClipType ct;
     Clipper2Lib::FillRule fr;
     int64_t area, count;
 
-    for (auto test_number : { 1, 2 })
+    for (auto test_number : { 1, 2, 3 })
     {
         bool success = false;
         if (LoadTestNum(ifs, test_number, false, subject, subject_open, clip, area, count, ct, fr))


### PR DESCRIPTION
On my machine, processing this (admittedly large) task with [the latest version](https://github.com/AngusJohnson/Clipper2/tree/bd837044313eec0ba120f47381b4c1faa41198dc) takes some 8-9 minutes, when on [the previous version](https://github.com/AngusJohnson/Clipper2/tree/76e923a2120f116c29c110da870d00b2618a3283) it takes a small number of seconds (~3-4 s).