### PR TITLE
Add test case for offsetting a somewhat degenerate contour

### DIFF
--- a/CPP/Tests/Tests/TestOffset.cpp
+++ b/CPP/Tests/Tests/TestOffset.cpp
@@ -21,3 +21,20 @@ TEST(Clipper2Tests, TestOrientationAfterOffsetting) {
 
     EXPECT_EQ(Clipper2Lib::IsPositive(input), Clipper2Lib::IsPositive(output));
 }
+
+TEST(Clipper2Tests, DoesNotSplitRegionWhenOffsetting) {
+
+    const Clipper2Lib::Path64 input = {
+        Clipper2Lib::Point64(1, 1),
+        Clipper2Lib::Point64(1, 4),
+        Clipper2Lib::Point64(2, 3),
+        Clipper2Lib::Point64(1, 2)
+    };
+
+    for (int delta = 1; delta <= 3; ++delta) {
+        Clipper2Lib::ClipperOffset clipper;
+        clipper.AddPath(input, Clipper2Lib::JoinType::Round, Clipper2Lib::EndType::Polygon);
+        const auto outputs = clipper.Execute(delta);
+        EXPECT_EQ(outputs.size(), 1);
+    }
+}


### PR DESCRIPTION
Noticed something that may appear as somewhat inconsistent behaviour: the output has two paths for delta = 2, but not for delta = 1 or delta = 3. Not saying that there isn't some "natural" explanation, though.

Also not saying this is a huge deal for me, or something I can't handle. Just thought you might want to know.