### PR TITLE
Simple cmake build script and linux build fixes

### DIFF
--- a/CPP/CMakeLists.txt
+++ b/CPP/CMakeLists.txt
@@ -47,3 +47,22 @@ target_link_libraries(ConsoleDemo1 PRIVATE
 set_target_properties(ConsoleDemo1 PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(ConsoleDemo1 PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_SOURCE_DIR}/lib")
 
+install( FILES  Examples/InflateDemo/rabbit.svg DESTINATION . )
+file(COPY Examples/InflateDemo/rabbit.svg DESTINATION ${CMAKE_BINARY_DIR} FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ )
+
+add_executable(InflateDemo1
+  Examples/InflateDemo/InflateDemo1.cpp
+  Utils/clipper.svg.cpp
+  Utils/ClipFileLoad.cpp
+  Utils/ClipFileSave.cpp
+)
+target_include_directories(InflateDemo1 PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(InflateDemo1 PRIVATE
+  -lm
+  Clipper2
+)
+set_target_properties(InflateDemo1 PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(InflateDemo1 PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_SOURCE_DIR}/lib")
+

--- a/CPP/CMakeLists.txt
+++ b/CPP/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.10)
+project(Clipper2 LANGUAGES C CXX)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_library(Clipper2 SHARED
+  Clipper2Lib/clipper.core.h
+  Clipper2Lib/clipper.engine.cpp
+  Clipper2Lib/clipper.engine.h
+  Clipper2Lib/clipper.h
+  Clipper2Lib/clipper.minkowski.h
+  Clipper2Lib/clipper.offset.cpp
+  Clipper2Lib/clipper.offset.h
+)
+
+target_include_directories(Clipper2
+  PUBLIC
+    Clipper2Lib
+   
+  SYSTEM INTERFACE
+    Clipper2Lib
+)
+
+target_link_libraries(Clipper2
+  PRIVATE
+    -lm
+)
+set_target_properties(Clipper2 PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(Clipper2 PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_SOURCE_DIR}/lib")
+
+add_executable(ConsoleDemo1
+  Examples/ConsoleDemo1/ConsoleDemo1.cpp
+  Utils/clipper.svg.cpp
+  Utils/ClipFileLoad.cpp
+  Utils/ClipFileSave.cpp
+)
+target_include_directories(ConsoleDemo1 PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(ConsoleDemo1 PRIVATE
+  -lm
+  Clipper2
+)
+set_target_properties(ConsoleDemo1 PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(ConsoleDemo1 PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_SOURCE_DIR}/lib")
+

--- a/CPP/CMakeLists.txt
+++ b/CPP/CMakeLists.txt
@@ -17,52 +17,76 @@ add_library(Clipper2 SHARED
 )
 
 target_include_directories(Clipper2
-  PUBLIC
-    Clipper2Lib
-   
-  SYSTEM INTERFACE
-    Clipper2Lib
+  PUBLIC Clipper2Lib
+  SYSTEM INTERFACE Clipper2Lib
 )
-
-target_link_libraries(Clipper2
-  PRIVATE
-    -lm
-)
+target_link_libraries(Clipper2 PRIVATE -lm)
 set_target_properties(Clipper2 PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(Clipper2 PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_SOURCE_DIR}/lib")
 
-add_executable(ConsoleDemo1
-  Examples/ConsoleDemo1/ConsoleDemo1.cpp
+add_library(Clipper2utils SHARED
   Utils/clipper.svg.cpp
   Utils/ClipFileLoad.cpp
   Utils/ClipFileSave.cpp
 )
-target_include_directories(ConsoleDemo1 PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}
-)
-target_link_libraries(ConsoleDemo1 PRIVATE
-  -lm
-  Clipper2
-)
+target_link_libraries(Clipper2utils PRIVATE -lm)
+set_target_properties(Clipper2utils PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(Clipper2utils PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_SOURCE_DIR}/lib")
+
+add_executable(ConsoleDemo1 Examples/ConsoleDemo1/ConsoleDemo1.cpp)
+target_include_directories(ConsoleDemo1 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(ConsoleDemo1 PRIVATE -lm Clipper2 Clipper2utils)
 set_target_properties(ConsoleDemo1 PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(ConsoleDemo1 PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_SOURCE_DIR}/lib")
 
 install( FILES  Examples/InflateDemo/rabbit.svg DESTINATION . )
 file(COPY Examples/InflateDemo/rabbit.svg DESTINATION ${CMAKE_BINARY_DIR} FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ )
 
-add_executable(InflateDemo1
-  Examples/InflateDemo/InflateDemo1.cpp
-  Utils/clipper.svg.cpp
-  Utils/ClipFileLoad.cpp
-  Utils/ClipFileSave.cpp
-)
-target_include_directories(InflateDemo1 PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}
-)
-target_link_libraries(InflateDemo1 PRIVATE
-  -lm
-  Clipper2
-)
+add_executable(InflateDemo1 Examples/InflateDemo/InflateDemo1.cpp)
+target_include_directories(InflateDemo1 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(InflateDemo1 PRIVATE -lm Clipper2 Clipper2utils)
 set_target_properties(InflateDemo1 PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(InflateDemo1 PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_SOURCE_DIR}/lib")
+
+
+option(PACKAGE_TESTS "Build the tests" ON)
+if(PACKAGE_TESTS)
+  # See: https://cliutils.gitlab.io/modern-cmake/chapters/testing/googletest.html
+
+  enable_testing()
+  include(GoogleTest)
+  add_subdirectory("${PROJECT_SOURCE_DIR}/Tests/googletest/")
+
+  macro(package_add_test TESTNAME FILES )
+    # create an executable in which the tests will be stored
+    add_executable(${TESTNAME} ${FILES})
+    # link the Google test infrastructure, mocking library, and a default main function to
+    # the test executable.  Remove g_test_main if writing your own main function.
+    target_link_libraries(${TESTNAME} gtest gmock gtest_main Clipper2 Clipper2utils)
+    # gtest_discover_tests replaces gtest_add_tests,
+    # see https://cmake.org/cmake/help/v3.10/module/GoogleTest.html for more options to pass to it
+    gtest_discover_tests(${TESTNAME}
+        # set a working directory so your project root so that you can find test data via paths relative to the project root
+        WORKING_DIRECTORY ${PROJECT_DIR}
+        PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}"
+    )
+    set_target_properties(${TESTNAME} PROPERTIES FOLDER tests)
+  endmacro()
+
+  package_add_test(test1 Tests/Tests/TestFromTextFile2.cpp )
+  package_add_test(test2 Tests/Tests/TestFromTextFile.cpp )
+  package_add_test(test3 Tests/Tests/TestIntersection.cpp )
+  package_add_test(test4 Tests/Tests/TestOffset.cpp )
+  package_add_test(test5 Tests/Tests/TestOpenPath.cpp )
+  package_add_test(test6 Tests/Tests/TestUnion.cpp )
+  package_add_test(test7 Tests/Tests/TestFromTextFile3.cpp )
+
+  install( FILES  ../Tests/Tests3.txt DESTINATION . )
+  install( FILES  ../Tests/Tests2.txt DESTINATION . )
+  install( FILES  ../Tests/Tests.txt DESTINATION . )
+
+  file(COPY ../Tests/Tests3.txt DESTINATION ${CMAKE_BINARY_DIR} FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ )
+  file(COPY ../Tests/Tests2.txt DESTINATION ${CMAKE_BINARY_DIR} FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ )
+  file(COPY ../Tests/Tests.txt DESTINATION ${CMAKE_BINARY_DIR} FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ )
+endif()
 

--- a/CPP/Examples/ConsoleDemo1/ConsoleDemo1.cpp
+++ b/CPP/Examples/ConsoleDemo1/ConsoleDemo1.cpp
@@ -20,6 +20,7 @@ void RunSavedTests(const std::string& filename,
   bool svg_draw, bool show_solution_coords);
 void DoBenchmark(int edge_cnt_start, int edge_cnt_end, int increment);
 void DoMemoryLeakTest();
+void System(const std::string &filename);
 
 int main()
 {
@@ -127,7 +128,7 @@ void DoSimpleTest(bool show_solution_coords)
   //save and display
   SvgAddSolution(svg, solution, false);
   SvgSaveToFile(svg, "solution1.svg", fr, 450, 450, 10);
-  system("solution1.svg");
+  System("solution1.svg");
 
   //SVG IMAGE #2
   //intersect a 9 point star with a circle
@@ -146,7 +147,7 @@ void DoSimpleTest(bool show_solution_coords)
   SvgAddClip(svg2, clip);
   SvgAddSolution(svg2, solution, false);
   SvgSaveToFile(svg2, "solution2.svg", fr, 450, 450, 10);
-  system("solution2.svg");
+  System("solution2.svg");
 }
 
 void RunSavedTests(const std::string& filename,
@@ -196,7 +197,7 @@ void RunSavedTests(const std::string& filename,
         SvgAddSolution(svg, solution, show_solution_coords);
         SvgAddOpenSolution(svg, solution_open, show_solution_coords);
         SvgSaveToFile(svg, filename2, fr, display_width, display_height, 20);
-        system(filename2.c_str());
+        System(filename2.c_str());
       }
     }
     else break;
@@ -234,7 +235,7 @@ void DoBenchmark(int edge_cnt_start, int edge_cnt_end, int increment)
   SvgAddSolution(svg, solution, false);
   SvgSaveToFile(svg, "solution3.svg", 
     fr_benchmark, display_width, display_height, 20);
-  system("solution3.svg");
+  System("solution3.svg");
 }
 
 void DoMemoryLeakTest()
@@ -260,4 +261,13 @@ void DoMemoryLeakTest()
   {
     std::cout << std::endl << "No memory leaks detected :)" << std::endl << std::endl;
   }
+}
+
+void System(const std::string &filename)
+{
+#ifdef WIN32
+  system(filename.c_str());
+#else
+  system(("firefox " + filename).c_str());
+#endif
 }

--- a/CPP/Examples/ConsoleDemo1/ConsoleDemo1.cpp
+++ b/CPP/Examples/ConsoleDemo1/ConsoleDemo1.cpp
@@ -240,6 +240,7 @@ void DoBenchmark(int edge_cnt_start, int edge_cnt_end, int increment)
 
 void DoMemoryLeakTest()
 {
+#ifdef WIN32
   int edge_cnt = 1000;
 
   Paths64 subject, clip;
@@ -261,6 +262,7 @@ void DoMemoryLeakTest()
   {
     std::cout << std::endl << "No memory leaks detected :)" << std::endl << std::endl;
   }
+#endif
 }
 
 void System(const std::string &filename)

--- a/CPP/Examples/InflateDemo/InflateDemo1.cpp
+++ b/CPP/Examples/InflateDemo/InflateDemo1.cpp
@@ -7,6 +7,7 @@
 using namespace std;
 using namespace Clipper2Lib;
 
+void System(const std::string &filename);
 
 int main(int argc, char* argv[])
 {
@@ -43,7 +44,7 @@ int main(int argc, char* argv[])
   SvgWriter svg;
   SvgAddSolution(svg, Paths64ToPathsD(pp), false);
   SvgSaveToFile(svg, "solution_off.svg", fr, 800, 600, 20);
-  system("solution_off.svg");
+  System("solution_off.svg");
 
   // Because ClipperOffset uses integer coordinates,
   // you'll need to scale coordinates when you 
@@ -69,7 +70,16 @@ int main(int argc, char* argv[])
   svg.Clear();
   SvgAddSolution(svg, ScalePaths<double, int64_t>(pp, 1/scale), false);   //scale back down
   SvgSaveToFile(svg, "solution_off2.svg", fr, 450, 720, 0);
-  system("solution_off2.svg");
+  System("solution_off2.svg");
 
 }
 //---------------------------------------------------------------------------
+
+void System(const std::string &filename)
+{
+#ifdef WIN32
+  system(filename.c_str());
+#else
+  system(("firefox " + filename).c_str());
+#endif
+}

--- a/CPP/Tests/Tests/TestFromTextFile.cpp
+++ b/CPP/Tests/Tests/TestFromTextFile.cpp
@@ -3,7 +3,11 @@
 #include "../../Utils/ClipFileLoad.h"
 
 TEST(Clipper2Tests, TestFromTextFile) {
+#ifdef WIN32
     std::ifstream ifs("../../../Tests/Tests.txt");
+#else
+    std::ifstream ifs("Tests.txt");
+#endif
     ASSERT_TRUE(ifs);
     ASSERT_TRUE(ifs.good());
 

--- a/CPP/Tests/Tests/TestFromTextFile2.cpp
+++ b/CPP/Tests/Tests/TestFromTextFile2.cpp
@@ -3,7 +3,11 @@
 #include "../../Utils/ClipFileLoad.h"
 
 TEST(Clipper2Tests, TestFromTextFile2) {
+#ifdef WIN32
     std::ifstream ifs("../../../Tests/Tests2.txt");
+#else
+    std::ifstream ifs("Tests2.txt");
+#endif
     ASSERT_TRUE(ifs);
     ASSERT_TRUE(ifs.good());
         

--- a/CPP/Tests/Tests/TestFromTextFile3.cpp
+++ b/CPP/Tests/Tests/TestFromTextFile3.cpp
@@ -42,7 +42,11 @@ std::vector<ResultRegion> ExtractResults(
 };
 
 TEST(Clipper2Tests, TestFromTextFile3) {
+#ifdef WIN32
     std::ifstream ifs("../../../Tests/Tests3.txt");
+#else
+    std::ifstream ifs("Tests3.txt");
+#endif
     ASSERT_TRUE(ifs);
     ASSERT_TRUE(ifs.good());
         

--- a/CPP/Utils/ClipFileLoad.h
+++ b/CPP/Utils/ClipFileLoad.h
@@ -8,6 +8,11 @@
 #include <fstream>
 #include <string>
 #include "../Clipper2Lib/clipper.h"
+#ifndef WIN32
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
 
 bool GetInt(std::string::const_iterator& s_it,
   const std::string::const_iterator& it_end, int64_t& value);

--- a/CPP/Utils/ClipFileSave.cpp
+++ b/CPP/Utils/ClipFileSave.cpp
@@ -5,6 +5,7 @@
 #include "ClipFileSave.h"
 #include "ClipFileLoad.h"
 #include <sstream>
+#include <cstring>
 
 using namespace std;
 using namespace Clipper2Lib;

--- a/CPP/Utils/Timer.h
+++ b/CPP/Utils/Timer.h
@@ -40,10 +40,10 @@ Example:
 struct Timer {
 private:
   std::streamsize old_precision;
-  int old_flags;
+  std::ios_base::fmtflags old_flags;
   bool paused_ = false;
-  std::chrono::steady_clock::time_point time_started_ = {};
-  std::chrono::steady_clock::duration duration_ = {};
+  std::chrono::high_resolution_clock::time_point time_started_ = {};
+  std::chrono::high_resolution_clock::duration duration_ = {};
   std::string time_text_ = "";
   
   void init(bool start_paused)
@@ -78,7 +78,7 @@ public:
   void pause()
   {
     if (paused_) return;
-    std::chrono::steady_clock::time_point now =
+    std::chrono::high_resolution_clock::time_point now =
       std::chrono::high_resolution_clock::now();
     duration_ += (now - time_started_);
     paused_ = true;
@@ -105,4 +105,4 @@ public:
   }
 };
 
-#endif CLIPPER_TIMER_H
+#endif // CLIPPER_TIMER_H

--- a/CPP/Utils/clipper.svg.cpp
+++ b/CPP/Utils/clipper.svg.cpp
@@ -272,15 +272,15 @@ namespace Clipper2Lib {
   //------------------------------------------------------------------------------
 
   inline bool Find(const std::string& text,
-    std::string::iterator& start, const std::string::iterator& end)
+    std::string::const_iterator& start, const std::string::const_iterator& end)
   {
     start = std::search(start, end, text.cbegin(), text.cend());
     return start != end;
   }
   //------------------------------------------------------------------------------
 
-  bool SvgReader::LoadPath(std::string::iterator& p,
-    const std::string::iterator& pe)
+  bool SvgReader::LoadPath(std::string::const_iterator& p,
+    const std::string::const_iterator& pe)
   {
     if (!Find("d=\"", p, pe)) return false;
     p += 3;
@@ -353,7 +353,7 @@ namespace Clipper2Lib {
       xml_buff << file.rdbuf();
       file.close();
       xml = xml_buff.str();
-      std::string::iterator p = xml.begin(), q, xml_end = xml.end();
+      std::string::const_iterator p = xml.cbegin(), q, xml_end = xml.cend();
 
       while (Find("<path", p, xml_end))
       {      

--- a/CPP/Utils/clipper.svg.h
+++ b/CPP/Utils/clipper.svg.h
@@ -106,8 +106,8 @@ namespace Clipper2Lib {
   {
   private:
       PathInfoList path_infos;
-      bool LoadPath(std::string::iterator& p,
-        const std::string::iterator& pe);
+      bool LoadPath(std::string::const_iterator& p,
+        const std::string::const_iterator& pe);
   public:
       std::string xml;
       bool LoadFromFile(const std::string &filename);

--- a/CPP/Utils/clipper.svg.utils.h
+++ b/CPP/Utils/clipper.svg.utils.h
@@ -13,6 +13,11 @@
 #include <string>
 #include "../Clipper2Lib/clipper.h"
 #include "./clipper.svg.h"
+#ifndef WIN32
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
 
 namespace Clipper2Lib {
 


### PR DESCRIPTION
Nice library wish I had found Clipper1 years ago.

Added a cmake build to the CPP directory.

Updated the C++ code to build on Ubuntu 22.04 using gcc 11.20. C++ standard set to C++17.

```
damian@damian-GP72-7RD:~/projects/checks/Clipper2/CPP/build$ make test
Running tests...
Test project /home/damian/projects/checks/Clipper2/CPP/build
    Start 1: Clipper2Tests.TestFromTextFile2
1/7 Test #1: Clipper2Tests.TestFromTextFile2 ................   Passed    0.02 sec
    Start 2: Clipper2Tests.TestFromTextFile
2/7 Test #2: Clipper2Tests.TestFromTextFile .................   Passed    0.10 sec
    Start 3: Clipper2Tests.TestBasicIntersection
3/7 Test #3: Clipper2Tests.TestBasicIntersection ............   Passed    0.00 sec
    Start 4: Clipper2Tests.TestOrientationAfterOffsetting
4/7 Test #4: Clipper2Tests.TestOrientationAfterOffsetting ...   Passed    0.00 sec
    Start 5: Clipper2Tests.TestSimpleOpenPath
5/7 Test #5: Clipper2Tests.TestSimpleOpenPath ...............   Passed    0.00 sec
    Start 6: Clipper2Tests.TestBasicUnion
6/7 Test #6: Clipper2Tests.TestBasicUnion ...................   Passed    0.00 sec
    Start 7: Clipper2Tests.TestFromTextFile3
7/7 Test #7: Clipper2Tests.TestFromTextFile3 ................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 7

Total Test time (real) =   0.15 sec
```

To build and test
```
cd CPP
mkdir build
cd build
cmake ..
make
make test
```