### PR TITLE
Fix for TPathD version of Area function

### DIFF
--- a/Delphi/Clipper2Lib/Clipper.Core.pas
+++ b/Delphi/Clipper2Lib/Clipper.Core.pas
@@ -1283,7 +1283,7 @@ end;
 function Area(const path: TPathD): Double;
 var
   i, highI: Integer;
-  p1,p2: PPoint64;
+  p1,p2: PPointD;
 begin
   //https://en.wikipedia.org/wiki/Shoelace_formula
   Result := 0.0;


### PR DESCRIPTION
The TPathD version of the Area function (Delphi) was casting the path elements to a PPoint64 instead of a PPointD which resulted in an incorrect result.