### PR TITLE
Updates to build Clipper2 with clang.

### DIFF
--- a/CPP/Clipper2Lib/clipper.engine.cpp
+++ b/CPP/Clipper2Lib/clipper.engine.cpp
@@ -18,7 +18,6 @@
 
 namespace Clipper2Lib {
 
-	static const double DefaultScale = 100;
 	static const double FloatingPointTolerance = 1.0e-12;
 
 	//Every closed path (or polygon) is made up of a series of vertices forming

--- a/CPP/Clipper2Lib/clipper.engine.h
+++ b/CPP/Clipper2Lib/clipper.engine.h
@@ -356,6 +356,9 @@ namespace Clipper2Lib {
 
 	};
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Woverloaded-virtual"
+
 	void Polytree64ToPolytreeD(const PolyPath64& polytree, PolyPathD& result);
 
 	class Clipper64 : public ClipperBase
@@ -449,6 +452,8 @@ namespace Clipper2Lib {
 		}
 
 	};
+#pragma clang diagnostic pop
+
 
 	using Clipper = Clipper64;
 

--- a/CPP/Clipper2Lib/clipper.engine.h
+++ b/CPP/Clipper2Lib/clipper.engine.h
@@ -356,8 +356,10 @@ namespace Clipper2Lib {
 
 	};
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Woverloaded-virtual"
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Woverloaded-virtual"
+#endif
 
 	void Polytree64ToPolytreeD(const PolyPath64& polytree, PolyPathD& result);
 
@@ -452,7 +454,9 @@ namespace Clipper2Lib {
 		}
 
 	};
-#pragma clang diagnostic pop
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
 
 
 	using Clipper = Clipper64;

--- a/CPP/Clipper2Lib/clipper.offset.h
+++ b/CPP/Clipper2Lib/clipper.offset.h
@@ -51,7 +51,7 @@ private:
 	bool merge_groups_ = true;
 	bool preserve_collinear_ = false;
 	bool reverse_solution_ = false;
-	bool reverse_orientation_ = false;
+	[[maybe_unused]] bool reverse_orientation_ = false;
 
 	void DoSquare(PathGroup& group, const Path64& path, size_t j, size_t k);
 	void DoMiter(PathGroup& group, const Path64& path, size_t j, size_t k, double cos_a);

--- a/CPP/Clipper2Lib/clipper.offset.h
+++ b/CPP/Clipper2Lib/clipper.offset.h
@@ -71,7 +71,7 @@ public:
 		miter_limit_(miter_limit), arc_tolerance_(arc_tolerance),
 		preserve_collinear_(preserve_collinear),
 		reverse_solution_(reverse_solution),
-		reverse_orientation_(reverse_orientation){ };
+		reverse_orientation_(reverse_orientation) {};
 
 	~ClipperOffset() { Clear(); };
 

--- a/CPP/Clipper2Lib/clipper.offset.h
+++ b/CPP/Clipper2Lib/clipper.offset.h
@@ -51,7 +51,7 @@ private:
 	bool merge_groups_ = true;
 	bool preserve_collinear_ = false;
 	bool reverse_solution_ = false;
-	[[maybe_unused]] bool reverse_orientation_ = false;
+	bool reverse_orientation_ = false;
 
 	void DoSquare(PathGroup& group, const Path64& path, size_t j, size_t k);
 	void DoMiter(PathGroup& group, const Path64& path, size_t j, size_t k, double cos_a);
@@ -71,7 +71,7 @@ public:
 		miter_limit_(miter_limit), arc_tolerance_(arc_tolerance),
 		preserve_collinear_(preserve_collinear),
 		reverse_solution_(reverse_solution),
-		reverse_orientation_(reverse_orientation) {};
+		reverse_orientation_(reverse_orientation) { (void)reverse_orientation_; };
 
 	~ClipperOffset() { Clear(); };
 

--- a/CPP/Examples/ConsoleDemo1/ConsoleDemo1.cpp
+++ b/CPP/Examples/ConsoleDemo1/ConsoleDemo1.cpp
@@ -177,11 +177,11 @@ void RunSavedTests(const std::string& filename,
       c.Execute(ct, fr, solution, solution_open);
       int64_t area2 = static_cast<int64_t>(Area(solution));
       int64_t count2 = solution.size();
-      int64_t count_diff = abs(count2 - count);
+      int64_t count_diff = std::labs(count2 - count);
       if (count && count_diff > 2 && count_diff/ static_cast<double>(count) > 0.02)
         std::cout << "  Test " << i << " path counts differ: Saved val= " <<
         count << "; New val=" << count2 << std::endl;
-      int64_t area_diff = std::abs(area2 - area);
+      int64_t area_diff = std::labs(area2 - area);
       if (area && (area_diff > 2) && (area_diff/static_cast<double>(area)) > 0.02)
         std::cout << "  Test " << i << " path areas differ: Saved val= " <<
         area << "; New val=" << area2 << std::endl;


### PR DESCRIPTION
Checked gcc, clang and visual studio 2019.

Changes are minimal. All tests pass and the examples run.