### PR TITLE
Problem: error: 'Clipper2Lib::ClipperD::Execute' hides overloaded virtual functions [-Werror,-Woverloaded-virtual]

### DIFF
--- a/CPP/Clipper2Lib/clipper.engine.h
+++ b/CPP/Clipper2Lib/clipper.engine.h
@@ -419,7 +419,7 @@ namespace Clipper2Lib {
 			AddPaths(ScalePaths<int64_t, double>(clips, scale_), PathType::Clip, false);
 		}
 
-		bool Execute(ClipType clip_type, FillRule fill_rule, PathsD& closed_paths)
+		bool ExecuteD(ClipType clip_type, FillRule fill_rule, PathsD& closed_paths)
 		{
 			Paths64 closed_paths64;
 			if (!ClipperBase::Execute(clip_type, fill_rule, closed_paths64)) return false;
@@ -427,7 +427,7 @@ namespace Clipper2Lib {
 			return true;
 		}
 
-		bool Execute(ClipType clip_type,
+		bool ExecuteD(ClipType clip_type,
 			FillRule fill_rule, PathsD& closed_paths, PathsD& open_paths)
 		{
 			Paths64 closed_paths64;
@@ -439,7 +439,7 @@ namespace Clipper2Lib {
 			return true;
 		}
 
-		bool Execute(ClipType clip_type,
+		bool ExecuteD(ClipType clip_type,
 			FillRule fill_rule, PolyTreeD& polytree, Paths64& open_paths)
 		{
 			PolyTree64 tree_result;

--- a/CPP/Clipper2Lib/clipper.h
+++ b/CPP/Clipper2Lib/clipper.h
@@ -52,7 +52,7 @@ namespace Clipper2Lib
     ClipperD clipper;
     clipper.AddSubject(subjects);
     clipper.AddClip(clips);
-    clipper.Execute(cliptype, fillrule, result);
+    clipper.ExecuteD(cliptype, fillrule, result);
     return result;
   }
 
@@ -90,7 +90,7 @@ namespace Clipper2Lib
     PathsD result;
     ClipperD clipper;
     clipper.AddSubject(subjects);
-    clipper.Execute(ClipType::Union, fillrule, result);
+    clipper.ExecuteD(ClipType::Union, fillrule, result);
     return result;
   }
 


### PR DESCRIPTION
Problem: `error: 'Clipper2Lib::ClipperD::Execute' hides overloaded virtual functions [-Werror,-Woverloaded-virtual]`

Solution: just rename the offending method