### PR TITLE
C# switch to netstandard2.0

### DIFF
--- a/CSharp/Clipper2Lib/Clipper.cs
+++ b/CSharp/Clipper2Lib/Clipper.cs
@@ -664,7 +664,7 @@ namespace Clipper2Lib
       else
       {
         while (result.Count > 2 &&
-          InternalClipper.CrossProduct(result[^1], result[^2], result[0]) == 0)
+          InternalClipper.CrossProduct(result[result.Count - 1], result[result.Count - 2], result[0]) == 0)
           result.RemoveAt(result.Count - 1);
         if (result.Count < 3)
           result.Clear();

--- a/CSharp/Clipper2Lib/Clipper2Lib.csproj
+++ b/CSharp/Clipper2Lib/Clipper2Lib.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
Currently the C# Clipper2Lib project uses netstandard2.1. However, netstardard2.0 is the recommended .NET API for .NET library code, https://docs.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1#which-net-standard-version-to-target. Especially the support for Net Framework allows the code to be used in a lot more (older) projects.

One line of code contained unsupported syntax in netstardard2.0, so that had to be changed.
The LangVersion 8 is the default for netstandard2.1, https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version.