### PR TITLE
Add test that holes are inside their corresponding parents

### DIFF
--- a/CPP/CMakeLists.txt
+++ b/CPP/CMakeLists.txt
@@ -83,7 +83,8 @@ if(PACKAGE_TESTS)
   package_add_test(test6 Tests/Tests/TestHoleOwnership.cpp )
   package_add_test(test7 Tests/Tests/TestTrimCollinear.cpp )
   package_add_test(test8 Tests/Tests/TestOrientation.cpp )
-
+  package_add_test(test9 Tests/Tests/TestHoleOwnership2.cpp )
+  
   install( FILES  ../Tests/PolytreeHoleOwner.txt DESTINATION . )
   install( FILES  ../Tests/Lines.txt DESTINATION . )
   install( FILES  ../Tests/Polygons.txt DESTINATION . )

--- a/CPP/CMakeLists.txt
+++ b/CPP/CMakeLists.txt
@@ -86,10 +86,12 @@ if(PACKAGE_TESTS)
   package_add_test(test9 Tests/Tests/TestHoleOwnership2.cpp )
   
   install( FILES  ../Tests/PolytreeHoleOwner.txt DESTINATION . )
+  install( FILES  ../Tests/PolytreeHoleOwner2.txt DESTINATION . )
   install( FILES  ../Tests/Lines.txt DESTINATION . )
   install( FILES  ../Tests/Polygons.txt DESTINATION . )
 
   file(COPY ../Tests/PolytreeHoleOwner.txt DESTINATION ${CMAKE_BINARY_DIR} FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ )
+  file(COPY ../Tests/PolytreeHoleOwner2.txt DESTINATION ${CMAKE_BINARY_DIR} FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ )
   file(COPY ../Tests/Lines.txt DESTINATION ${CMAKE_BINARY_DIR} FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ )
   file(COPY ../Tests/Polygons.txt DESTINATION ${CMAKE_BINARY_DIR} FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ )
 endif()


### PR DESCRIPTION
Some of my existing tests started failing after the latest update (the fix to #120), and on my side it seems to boil down to something like this.