### PR TITLE
Make functions in `Clipper2` available for `Clipper2utils` to use (fixes a MacOS build issue)

### DIFF
--- a/CPP/CMakeLists.txt
+++ b/CPP/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(Clipper2utils SHARED
   Utils/ClipFileLoad.cpp
   Utils/ClipFileSave.cpp
 )
-target_link_libraries(Clipper2utils PRIVATE -lm)
+target_link_libraries(Clipper2utils PRIVATE -lm Clipper2)
 set_target_properties(Clipper2utils PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(Clipper2utils PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_SOURCE_DIR}/lib")
 


### PR DESCRIPTION
Resolves #139.