### PR TITLE
Inherit from `ClipperBase` privately

### DIFF
--- a/CPP/Clipper2Lib/clipper.engine.h
+++ b/CPP/Clipper2Lib/clipper.engine.h
@@ -351,7 +351,7 @@ namespace Clipper2Lib {
 	void Polytree64ToPolytreeD(const PolyPath64& polytree, PolyPathD& result);
 
 
-	class Clipper64 : public ClipperBase
+	class Clipper64 : private ClipperBase
 	{
 	public:
 		using ClipperBase::ClipperBase;
@@ -387,9 +387,18 @@ namespace Clipper2Lib {
 			return ClipperBase::Execute(clip_type, fill_rule, polytree, open_paths);
 		}
 
+		void SetPreserveCollinear(bool preserve_collinear)
+		{
+			PreserveCollinear = preserve_collinear;
+		}
+
+		void SetReverseSolution(bool reverse_solution)
+		{
+			ReverseSolution = reverse_solution;
+		}
 	};
 
-	class ClipperD : public ClipperBase {
+	class ClipperD : private ClipperBase {
 	private:
 		double scale_ = 1.0;
 	public:

--- a/CPP/Clipper2Lib/clipper.offset.cpp
+++ b/CPP/Clipper2Lib/clipper.offset.cpp
@@ -336,9 +336,9 @@ void ClipperOffset::DoGroupOffset(PathGroup& group, double delta)
 	{
 		//clean up self-intersections ...
 		Clipper64 c;
-		c.PreserveCollinear = false;
+		c.SetPreserveCollinear(false);
 		//the solution should retain the orientation of the input
-		c.ReverseSolution = reverse_solution_ != group.is_reversed_;
+		c.SetReverseSolution(reverse_solution_ != group.is_reversed_);
 		c.AddSubject(group.paths_out_);
 		if (group.is_reversed_)
 			c.Execute(ClipType::Union, FillRule::Negative, group.paths_out_);
@@ -379,9 +379,9 @@ Paths64 ClipperOffset::Execute(double delta)
 	{
 		//clean up self-intersections ...
 		Clipper64 c;
-		c.PreserveCollinear = false;
+		c.SetPreserveCollinear(false);
 		//the solution should retain the orientation of the input
-		c.ReverseSolution = reverse_solution_ != groups_[0].is_reversed_;
+		c.SetReverseSolution(reverse_solution_ != groups_[0].is_reversed_);
 
 		c.AddSubject(solution);
 		if (groups_[0].is_reversed_)

--- a/CPP/Tests/Tests/TestPolytreeUnion.cpp
+++ b/CPP/Tests/Tests/TestPolytreeUnion.cpp
@@ -20,7 +20,7 @@ TEST(Clipper2Tests, TestPolytreeUnion) {
     else
     {
       //because clipping ops normally return Positive solutions
-      clipper.ReverseSolution = true;
+      clipper.SetReverseSolution(true);
       clipper.Execute(ClipType::Union,
         FillRule::Negative, solution, open_paths);
     }


### PR DESCRIPTION
I still have minor issues with inheritance here, so I thought that one way of preventing future users and maintainers from shooting themselves in the foot might be to have `Clipper64` and `ClipperD` inherit `ClipperBase` privately (and not publicly). So this is kind of alternative to #142. Still more of a suggestion – there's still nothing wrong with the current code itself.