### PR TITLE
Fix negative numbers not being read correctly in GetFloat

### DIFF
--- a/CPP/Clipper2Lib/clipper.h
+++ b/CPP/Clipper2Lib/clipper.h
@@ -312,6 +312,8 @@ namespace Clipper2Lib
       if (iter == start_iter || dec_pos == 0) return false;
       if (dec_pos > 0)
         val *= std::pow(10, -dec_pos);
+      if (is_neg)
+        val *= -1;
       return true;
     }
 


### PR DESCRIPTION
GetFloat correctly detects negative numbers but a slight oversight means the value is not negated before return.