### PR TITLE
add missing header

### DIFF
--- a/CPP/Clipper2Lib/clipper.minkowski.h
+++ b/CPP/Clipper2Lib/clipper.minkowski.h
@@ -14,7 +14,9 @@
 #include <cstdlib>
 #include <vector>
 #include <string>
+
 #include "clipper.core.h"
+#include "clipper.engine.h"
 
 namespace Clipper2Lib 
 {


### PR DESCRIPTION
Hi, I was trying to create Rust bindings of the C++ version of Clipper2 and I noticed this missing include directive which makes the build fail.

The build was failing only because `FillRule` is defined in `clipper.engine.h` which wasn't included in `clipper.minkowski.h`. I've simply added it, but maybe it makes more sense to move the `FillRule` declaration in `clipper.core.h` to reduce the number of headers included.