### PR TITLE
Clean-ups

### DIFF
--- a/CSharp/Clipper2Lib/Clipper.Core.cs
+++ b/CSharp/Clipper2Lib/Clipper.Core.cs
@@ -550,9 +550,9 @@ namespace Clipper2Lib
           if (i == len) break;
         }
 
-        Point64 curr, prev;
+        Point64 prev;
 
-        curr = polygon[i];
+        Point64 curr = polygon[i];
         if (i > 0) prev = polygon[i - 1];
         else prev = polygon[len - 1];
 

--- a/CSharp/Clipper2Lib/Clipper.Engine.cs
+++ b/CSharp/Clipper2Lib/Clipper.Engine.cs
@@ -3411,7 +3411,6 @@ namespace Clipper2Lib
       } while (op != or1.pts);
       if (result == PointInPolygonResult.IsOn)
         return Area(op) < Area(or2.pts!);
-      else
       return result == PointInPolygonResult.IsInside;
     }
 

--- a/CSharp/Clipper2Lib/Clipper.Offset.cs
+++ b/CSharp/Clipper2Lib/Clipper.Offset.cs
@@ -175,11 +175,9 @@ namespace Clipper2Lib
         for (int j = 0; j < p.Count; j++)
         {
           if (p[j].Y < lp.Y) continue;
-          if (p[j].Y > lp.Y || p[j].X < lp.X)
-          {
-            result = i;
-            lp = p[j];
-          }
+          if (p[j].Y <= lp.Y && p[j].X >= lp.X) continue;
+          result = i;
+          lp = p[j];
         }
       }
       return result;

--- a/CSharp/Clipper2Lib/Clipper.cs
+++ b/CSharp/Clipper2Lib/Clipper.cs
@@ -581,8 +581,12 @@ namespace Clipper2Lib
     public static PathsD PolyTreeToPathsD(PolyTreeD polyTree)
     {
       PathsD result = new PathsD();
-      foreach (PolyPathD p in polyTree)
+      foreach (var polyPathBase in polyTree)
+      {
+        PolyPathD p = (PolyPathD)polyPathBase;
         AddPolyNodeToPathsD(p, result);
+      }
+
       return result;
     }
 
@@ -629,9 +633,7 @@ namespace Clipper2Lib
     {
       int len = path.Count;
       if (len < 5) return path;
-      List<bool> flags = new List<bool>(new bool[len]);
-      flags[0] = true;
-      flags[len - 1] = true;
+      List<bool> flags = new List<bool>(new bool[len]) { [0] = true, [len - 1] = true };
       RDP(path, 0, len - 1, Sqr(epsilon), flags);
       Path64 result = new Path64(len);
       for (int i = 0; i < len; ++i)
@@ -670,9 +672,7 @@ namespace Clipper2Lib
     {
       int len = path.Count;
       if (len < 5) return path;
-      List<bool> flags = new List<bool>(new bool[len]);
-      flags[0] = true;
-      flags[len - 1] = true;
+      List<bool> flags = new List<bool>(new bool[len]) { [0] = true, [len - 1] = true };
       RDP(path, 0, len - 1, Sqr(epsilon), flags);
       PathD result = new PathD(len);
       for (int i = 0; i < len; ++i)
@@ -713,11 +713,9 @@ namespace Clipper2Lib
       for (i++; i < len - 1; i++)
       {
         if (InternalClipper.CrossProduct(
-          last, path[i], path[i + 1]) != 0)
-        {
-          last = path[i];
-          result.Add(last);
-        }
+              last, path[i], path[i + 1]) == 0) continue;
+        last = path[i];
+        result.Add(last);
       }
 
       if (isOpen)


### PR DESCRIPTION
Address compiler warning about invalid cast exception in foreach loop. Use constructor calls in some places.
Reduce some conditional nesting.
Redundant else