### PR TITLE
Clean-up unused reference

### DIFF
--- a/CSharp/Clipper2Lib/Clipper.Core.cs
+++ b/CSharp/Clipper2Lib/Clipper.Core.cs
@@ -417,6 +417,10 @@ namespace Clipper2Lib
   {
     public Paths64(int reserve = 0) : base(reserve) { }
     public Paths64(Paths64 paths) : base(paths) { }
+
+    public Paths64(IEnumerable<Path64> paths) : base(paths)
+    {
+    }
   }
 
   public class PathD : List<PointD>

--- a/CSharp/Clipper2Lib/Clipper.cs
+++ b/CSharp/Clipper2Lib/Clipper.cs
@@ -12,6 +12,7 @@
 * License   :  http://www.boost.org/LICENSE_1_0.txt                            *
 *******************************************************************************/
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/CSharp/Utils/SVG/Clipper.SVG.Utils.cs
+++ b/CSharp/Utils/SVG/Clipper.SVG.Utils.cs
@@ -6,7 +6,6 @@
 * License   :  http://www.boost.org/LICENSE_1_0.txt                            *
 *******************************************************************************/
 
-using System.Collections.Generic;
 using System.IO;
 
 namespace Clipper2Lib


### PR DESCRIPTION
Allow IEnumerable to be passed in Paths constructor.
IDE highlighted missing nullable.