### PR TITLE
Do not return empty paths from `RectClip` for multiple paths

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.h
@@ -273,7 +273,11 @@ namespace Clipper2Lib {
       else if (rect.Contains(pathRec))
         result.push_back(p);
       else
-        result.push_back(rc.Execute(p));
+      {
+        Path64 path = rc.Execute(p);
+        if (!path.empty())
+          result.push_back(std::move(path));
+      }
     }
     return result;
   }


### PR DESCRIPTION
I'm using the new `RectClip` functionality to check if any of my paths overlap a certain rectangle. (Previously was using generic intersection clipping for this, and now trying this hopefully much faster method.)

    bool isOverlap = !RectClip(rect, paths).empty();

Noticed that this doesn't work, because empty contours can be returned (so the result has paths that are just empty, but the result vector itself isn't empty).

First started to handle this on the call site (check if any of the returned paths is non-empty), but then realized that maybe it's better to handle this on the library side, so that the code on the call site can stay as simple as above?