### PR TITLE
Fix what appears to be a bug in `RectClip` for single `Path64` input

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.h
@@ -252,8 +252,12 @@ namespace Clipper2Lib {
 
   inline Path64 RectClip(const Rect64& rect, const Path64& path)
   {
-    if (rect.IsEmpty() || path.empty() ||
-      !rect.Contains(Bounds(path))) return Path64();
+    if (rect.IsEmpty() || path.empty()) return Path64();
+
+    Rect64 pathRec = Bounds(path);
+    if (!rect.Intersects(pathRec)) return Path64();
+    if (rect.Contains(pathRec)) return path;
+
     RectClip64 rc(rect);
     return rc.Execute(path);
   }


### PR DESCRIPTION
Problem: `RectClip` for single `Path64` input returns an empty solution, if the clipping rectangle does not completely _contain_ the (bounding rectangle of the) input path.

Solution: Return an empty solution if the rects do not _intersect_.

Bonus: Return the input path, if the clipping rectangle completely contains the (bounding rectangle of the) input path. (Similarly as in `RectClip` for `Paths64` input.)