### PR TITLE
Fix shared lib export of Polytree64ToPolytreeD when compiling with gcc

### DIFF
--- a/CPP/Clipper2Lib/src/clipper.engine.cpp
+++ b/CPP/Clipper2Lib/src/clipper.engine.cpp
@@ -3488,7 +3488,7 @@ namespace Clipper2Lib {
 		}
 	}
 
-	inline void Polytree64ToPolytreeD(const PolyPath64& polytree, PolyPathD& result)
+	void Polytree64ToPolytreeD(const PolyPath64& polytree, PolyPathD& result)
 	{
 		result.Clear();
 		PolyPath64ToPolyPathD(polytree, result);


### PR DESCRIPTION
When library built with gcc, the `Polytree64ToPolytreeD` is not exported from `clipper.engine` module as it is (re)declared as `inline` on the module level.