### PR TITLE
Fix missing #include.

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.core.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.core.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <iostream>
 #include <algorithm>
+#include <limits>
 
 namespace Clipper2Lib 
 {


### PR DESCRIPTION
Needed for usage of `std::numeric_limits` in this header.