### PR TITLE
Add initialized elements to internal lists if user supplies capacity argument to constructor

### DIFF
--- a/CSharp/Clipper2Lib/Clipper.Core.cs
+++ b/CSharp/Clipper2Lib/Clipper.Core.cs
@@ -440,27 +440,55 @@ namespace Clipper2Lib
   public class Path64 : List<Point64> 
   {
     private Path64() : base() { }
-    public Path64(int capacity = 0) : base(capacity) { }
+
+    public Path64(int capacity = 0) : base(capacity)
+    {
+      for (int i = 0; i < capacity; i++)
+      {
+        Add(new Point64());
+      }
+    }
     public Path64(IEnumerable<Point64> path) : base(path) { }
   }
   public class Paths64 : List<Path64>
   {
     private Paths64() : base() { }
-    public Paths64(int capacity = 0) : base(capacity) { }
+
+    public Paths64(int capacity = 0) : base(capacity)
+    {
+      for (int i = 0; i < capacity; i++)
+      {
+        Add(new Path64());
+      }
+    }
     public Paths64(IEnumerable<Path64> paths) : base(paths) { }
   }
 
   public class PathD : List<PointD>
   {
     private PathD() : base() { }
-    public PathD(int capacity = 0) : base(capacity) { }
+
+    public PathD(int capacity = 0) : base(capacity)
+    {
+      for (int i = 0; i < capacity; i++)
+      {
+        Add(new PointD());
+      }
+    }
     public PathD(IEnumerable<PointD> path) : base(path) { }
   }
 
   public class PathsD : List<PathD>
   {
     private PathsD() : base() { }
-    public PathsD(int capacity = 0) : base(capacity) { }
+
+    public PathsD(int capacity = 0) : base(capacity)
+    {
+      for (int i = 0; i < capacity; i++)
+      {
+        Add(new PathD());
+      }
+    }
     public PathsD(IEnumerable<PathD> paths) : base(paths) { }
   }
 


### PR DESCRIPTION
Historically, Clipper made the use of mutable arrays (lists) obvious. In its current form, this is tucked away from view. The user can still provide an argument to the constructor, which sets the capacity, but it does not initialize the members of the internal list. This can be annoying.

This PR makes the constructor construct a valid entry in each list if the capacity is provided. This allows for easier workflow when trying to work with list entries under threading contexts and avoids the user having to insert boilerplate functions to prepare lists in such scenarios.