### PR TITLE
fix wrong compiler flags on MinGW

### DIFF
--- a/CPP/CMakeLists.txt
+++ b/CPP/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(Clipper2Z
   PUBLIC Clipper2Lib/include
 )
 
-if (WIN32)
+if (MSVC)
   target_compile_options(Clipper2 PRIVATE /W4 /WX)
   target_compile_options(Clipper2Z PRIVATE /W4 /WX)
 else()


### PR DESCRIPTION
When using MinGW to compile on Windows, the CMake script still specifies MSVC-style options for the compiler. This PR simply makes it check for MSVC instead of any Windows environment.