### PR TITLE
Use C++ variadic templates for MakePath

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.h
@@ -11,6 +11,7 @@
 #define CLIPPER_H
 
 #include <cstdlib>
+#include <type_traits>
 #include <vector>
 
 #include "clipper.core.h"
@@ -588,6 +589,19 @@ namespace Clipper2Lib {
     return true;
   }
 
+  template<typename T, std::size_t N,
+           typename std::enable_if<std::is_integral<T>::value &&
+                                   !std::is_same<char, T>::value, bool
+                                   >::type = true>
+  inline Path64 MakePath(const T(&list)[N])
+  {
+    static_assert(N % 2 == 0, "MakePath requires an even number of arguments");
+    Path64 result(N / 2);
+    for (size_t i = 0; i < N; ++i)
+      result[i / 2] = Point64{list[i], list[++i]};
+    return result;
+  }
+
   inline Path64 MakePath(const std::string& s)
   {
     const std::string skip_chars = " ,(){}[]";
@@ -605,7 +619,20 @@ namespace Clipper2Lib {
     }
     return result;
   }
-  
+
+  template<typename T, std::size_t N,
+           typename std::enable_if<std::is_arithmetic<T>::value &&
+                                   !std::is_same<char, T>::value, bool
+                                   >::type = true>
+  inline PathD MakePathD(const T(&list)[N])
+  {
+    static_assert(N % 2 == 0, "MakePathD requires an even number of arguments");
+    PathD result(N / 2);
+    for (size_t i = 0; i < N; ++i)
+      result[i / 2] = PointD{list[i], list[++i]};
+    return result;
+  }
+
   inline PathD MakePathD(const std::string& s)
   {
     const std::string skip_chars = " ,(){}[]";

--- a/CPP/Examples/Inflate/Inflate.cpp
+++ b/CPP/Examples/Inflate/Inflate.cpp
@@ -25,7 +25,7 @@ void DoSimpleShapes()
 
   FillRule fr2 = FillRule::EvenOdd;
   SvgWriter svg2;
-  op1.push_back(MakePath("80,60, 20,20 180,20 180,80, 20,180 180,180"));
+  op1.push_back(MakePath({80,60, 20,20, 180,20, 180,80, 20,180, 180,180}));
   op2 = InflatePaths(op1, 20, JoinType::Square, EndType::Butt);
   SvgAddOpenSubject(svg2, op1, fr2, false);
   SvgAddSolution(svg2, Paths64ToPathsD(op2), fr2, false);
@@ -48,7 +48,7 @@ void DoSimpleShapes()
 
   //triangle offset - with large miter
   Paths64 p, pp;
-  p.push_back(MakePath("30, 150, 60, 350, 0, 350"));
+  p.push_back(MakePath({30, 150, 60, 350, 0, 350}));
   pp.insert(pp.end(), p.begin(), p.end());
 
   for (int i = 0; i < 5; ++i)
@@ -61,7 +61,7 @@ void DoSimpleShapes()
 
   //rectangle offset - both squared and rounded
   p.clear();
-  p.push_back(MakePath("100,30, 340,30, 340,230, 100,230"));
+  p.push_back(MakePath({100,30, 340,30, 340,230, 100,230}));
   pp.insert(pp.end(), p.begin(), p.end());
   //nb: using the ClipperOffest class directly here to control 
   //different join types within the same offset operation

--- a/CPP/Examples/UsingZ/UsingZ.cpp
+++ b/CPP/Examples/UsingZ/UsingZ.cpp
@@ -45,7 +45,7 @@ void TestingZ_Int64()
   MyClass mc;
   Clipper64 c64;
 
-  subject.push_back(MakePath("100, 50, 10, 79, 65, 2, 65, 98, 10, 21 "));
+  subject.push_back(MakePath({100, 50, 10, 79, 65, 2, 65, 98, 10, 21 }));
   c64.AddSubject(subject);
   c64.SetZCallback(
     std::bind(&MyClass::myZCB, mc, std::placeholders::_1,
@@ -76,7 +76,7 @@ void TestingZ_Double()
   MyClass mc;
   ClipperD c;
 
-  subject.push_back(MakePathD("100, 50, 10, 79, 65, 2, 65, 98, 10, 21 "));
+  subject.push_back(MakePathD({100, 50, 10, 79, 65, 2, 65, 98, 10, 21 }));
   c.AddSubject(subject);
   c.SetZCallback(
     std::bind(&MyClass::myZCBD, mc, std::placeholders::_1,

--- a/CPP/Tests/TestOrientation.cpp
+++ b/CPP/Tests/TestOrientation.cpp
@@ -11,7 +11,7 @@ TEST(Clipper2Tests, TestNegativeOrientation) {
   subjects.push_back(MakePath("(10,10) (10,110) (110,110) (110,10)"));
   EXPECT_FALSE(IsPositive(subjects[0]));
   EXPECT_FALSE(IsPositive(subjects[1]));
-  clips.push_back(MakePath("50,50 50,150 150,150 150,50"));
+  clips.push_back(MakePath({50,50, 50,150, 150,150, 150,50}));
   EXPECT_FALSE(IsPositive(clips[0]));
 
   solution = Union(subjects, clips, FillRule::Negative);

--- a/CPP/Tests/TestPolytreeIntersection.cpp
+++ b/CPP/Tests/TestPolytreeIntersection.cpp
@@ -8,10 +8,10 @@ TEST(Clipper2Tests, TestPolyTreeIntersection)
     Clipper64 clipper;
 
     Paths64 subject; 
-    subject.push_back( MakePath("0,0  0,5  5,5  5,0") );
+    subject.push_back( MakePath({0,0,  0,5,  5,5,  5,0}) );
     clipper.AddSubject(subject);
     Paths64 clip;
-    clip.push_back( MakePath("1,1  1,6  6,6  6,1") );
+    clip.push_back( MakePath({1,1,  1,6,  6,6,  6,1}) );
     clipper.AddClip (clip);
 
     PolyTree64 solution;

--- a/CPP/Tests/TestPolytreeUnion.cpp
+++ b/CPP/Tests/TestPolytreeUnion.cpp
@@ -6,8 +6,8 @@ using namespace Clipper2Lib;
 TEST(Clipper2Tests, TestPolytreeUnion) {
 
     Paths64 subject;
-    subject.push_back(MakePath("0,0  0,5  5,5  5,0"));
-    subject.push_back(MakePath("1,1  1,6  6,6  6,1"));
+    subject.push_back(MakePath({0,0,  0,5,  5,5,  5,0}));
+    subject.push_back(MakePath({1,1,  1,6,  6,6,  6,1}));
 
     Clipper64 clipper;
     clipper.AddSubject(subject);

--- a/CPP/Tests/TestRectClip.cpp
+++ b/CPP/Tests/TestRectClip.cpp
@@ -10,27 +10,27 @@ TEST(Clipper2Tests, TestRectClip)
   Rect64 rect = Rect64(100,100, 700, 500);
   clp.push_back(rect.AsPath());
 
-  sub.push_back(MakePath("100,100, 700,100, 700,500, 100,500"));
+  sub.push_back(MakePath({100,100, 700,100, 700,500, 100,500}));
   sol = RectClip(rect, sub);
   EXPECT_TRUE(Area(sol) == Area(sub));
 
   sub.clear();
-  sub.push_back(MakePath("110,110, 700,100, 700,500, 100,500"));
+  sub.push_back(MakePath({110,110, 700,100, 700,500, 100,500}));
   sol = RectClip(rect, sub);
   EXPECT_TRUE(Area(sol) == Area(sub));
 
   sub.clear();
-  sub.push_back(MakePath("90,90, 700,100, 700,500, 100,500"));
+  sub.push_back(MakePath({90,90, 700,100, 700,500, 100,500}));
   sol = RectClip(rect, sub);
   EXPECT_TRUE(Area(sol) == Area(clp));
 
   sub.clear();
-  sub.push_back(MakePath("90,90, 710,90, 710,510, 90,510"));
+  sub.push_back(MakePath({90,90, 710,90, 710,510, 90,510}));
   sol = RectClip(rect, sub);
   EXPECT_TRUE(Area(sol) == Area(clp));
 
   sub.clear();
-  sub.push_back(MakePath("110,110, 690,110, 690,490, 110,490"));
+  sub.push_back(MakePath({110,110, 690,110, 690,490, 110,490}));
   sol = RectClip(rect, sub);
   EXPECT_TRUE(Area(sol) == Area(sub));
 
@@ -38,22 +38,22 @@ TEST(Clipper2Tests, TestRectClip)
   clp.clear();
   rect = Rect64(390, 290, 410, 310);
   clp.push_back(rect.AsPath());
-  sub.push_back(MakePath("410,290 500,290 500,310 410,310"));
+  sub.push_back(MakePath({410,290, 500,290, 500,310, 410,310}));
   sol = RectClip(rect, sub);
   EXPECT_TRUE(sol.empty());
 
   sub.clear();
-  sub.push_back(MakePath("430,290 470,330 390,330"));
+  sub.push_back(MakePath({430,290, 470,330, 390,330}));
   sol = RectClip(rect, sub);
   EXPECT_TRUE(sol.empty());
 
   sub.clear();
-  sub.push_back(MakePath("450,290 480,330 450,330"));
+  sub.push_back(MakePath({450,290, 480,330, 450,330}));
   sol = RectClip(rect, sub);
   EXPECT_TRUE(sol.empty());
 
   sub.clear();
-  sub.push_back(MakePath("208,66 366,112 402,303 234,332 233,262 243,140 215,126 40,172"));
+  sub.push_back(MakePath({208,66, 366,112, 402,303, 234,332, 233,262, 243,140, 215,126, 40,172}));
   rect = Rect64(237, 164, 322, 248);
   sol = RectClip(rect, sub);
   const auto solBounds = Bounds(sol);

--- a/CPP/Tests/TestTrimCollinear.cpp
+++ b/CPP/Tests/TestTrimCollinear.cpp
@@ -6,22 +6,22 @@ using namespace Clipper2Lib;
 TEST(Clipper2Tests, TestTrimCollinear) {
       
   Path64 input1 = 
-    MakePath("10,10, 10,10, 50,10, 100,10, 100,100, 10,100, 10,10, 20,10");
+    MakePath({10,10, 10,10, 50,10, 100,10, 100,100, 10,100, 10,10, 20,10});
   Path64 output1 = TrimCollinear(input1, false);
   EXPECT_EQ(output1.size(), 4);
 
   Path64 input2 = 
-    MakePath("10,10, 10,10, 100,10, 100,100, 10,100, 10,10, 10,10");
+    MakePath({10,10, 10,10, 100,10, 100,100, 10,100, 10,10, 10,10});
   Path64 output2 = TrimCollinear(input2, true);
   EXPECT_EQ(output2.size(), 5);
 
-  Path64 input3 = MakePath("10,10, 10,50, 10,10, 50,10,50,50, \
-    50,10, 70,10, 70,50, 70,10, 50,10, 100,10, 100,50, 100,10");
+  Path64 input3 = MakePath({10,10, 10,50, 10,10, 50,10,50,50,
+    50,10, 70,10, 70,50, 70,10, 50,10, 100,10, 100,50, 100,10});
   Path64 output3 = TrimCollinear(input3);
   EXPECT_EQ(output3.size(), 0);
 
-  Path64 input4 = MakePath("2,3, 3,4, 4,4, 4,5, 7,5, \
-    8,4, 8,3, 9,3, 8,3, 7,3, 6,3, 5,3, 4,3, 3,3, 2,3");
+  Path64 input4 = MakePath({2,3, 3,4, 4,4, 4,5, 7,5,
+    8,4, 8,3, 9,3, 8,3, 7,3, 6,3, 5,3, 4,3, 3,3, 2,3});
   Path64 output4a = TrimCollinear(input4);
   Path64 output4b = TrimCollinear(output4a);
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The <b>Clipper2</b> library performs **intersection**, **union**, **difference**
 <pre>
       //C++
       Paths64 subject, clip, solution;
-      subject.push_back(MakePath("100, 50, 10, 79, 65, 2, 65, 98, 10, 21"));
-      clip.push_back(MakePath("98, 63, 4, 68, 77, 8, 52, 100, 19, 12"));
+      subject.push_back(MakePath({100, 50, 10, 79, 65, 2, 65, 98, 10, 21}));
+      clip.push_back(MakePath({98, 63, 4, 68, 77, 8, 52, 100, 19, 12}));
       solution = Intersect(subject, clip, FillRule::NonZero);</pre>
 <pre>      //C#
       Paths64 subj = new Paths64();


### PR DESCRIPTION
This PR adds variadic template functions for MakePath and MakePathD. In addition to being more in keeping with modern C++ style, they allow the compiler to validate the arguments and optimize away most of the runtime initialization code.

I converted over most of the tests, but left one to retain coverage of the existing string-based MakePath and MakePathD.