### PR TITLE
Fixed C# TestLines checking area

### DIFF
--- a/CSharp/Clipper2Lib.Tests/Tests1/Tests/TestLines.cs
+++ b/CSharp/Clipper2Lib.Tests/Tests1/Tests/TestLines.cs
@@ -29,7 +29,7 @@ namespace Clipper2Lib.UnitTests
         if (area > 0)
         {
           double area2 = Clipper.Area(solution);
-          double a = area2 / area2;
+          double a = area / area2;
           Assert.IsTrue(a > 0.995 && a < 1.005,
             string.Format("Incorrect area in test {0}", i));
         }

--- a/CSharp/Utils/ClipFileIO/Clipper.FileIO.cs
+++ b/CSharp/Utils/ClipFileIO/Clipper.FileIO.cs
@@ -58,14 +58,14 @@ namespace Clipper2Lib
             nlCnt++;
             if (nlCnt == 2)
             {
-              if (p.Count > 2) pp.Add(p);
+              if (p.Count > 0) pp.Add(p);
               p = new Path64();
             }
           }
           i++;
         }
       }
-      if (p.Count > 2) pp.Add(p);
+      if (p.Count > 0) pp.Add(p);
       return pp;
     }
     //------------------------------------------------------------------------------


### PR DESCRIPTION
TestLines in C# version did not check the area.
I've enabled this check in `TestOpenPaths()`.

By doing so, test cases 1 and 16 fail, because `PathFromStr(..)` skips short paths.
I've fixed that too.

Then, all test pass.