### PR TITLE
Exception macro compatible with MSVC

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.core.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.core.h
@@ -22,7 +22,7 @@
 namespace Clipper2Lib
 {
 
-#if defined(__cpp_exceptions) && __cpp_exceptions || (defined(__EXCEPTIONS) && __EXCEPTIONS)
+#if (defined(__cpp_exceptions) && __cpp_exceptions) || (defined(__EXCEPTIONS) && __EXCEPTIONS)
 
   class Clipper2Exception : public std::exception {
   public:
@@ -61,7 +61,7 @@ namespace Clipper2Lib
 
   static void DoError(int error_code)
   {
-#if defined(__cpp_exceptions) && __cpp_exceptions || (defined(__EXCEPTIONS) && __EXCEPTIONS)
+#if (defined(__cpp_exceptions) && __cpp_exceptions) || (defined(__EXCEPTIONS) && __EXCEPTIONS)
     switch (error_code)
     {
     case precision_error_i:

--- a/CPP/Clipper2Lib/include/clipper2/clipper.core.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.core.h
@@ -22,7 +22,7 @@
 namespace Clipper2Lib
 {
 
-#if __cpp_exceptions
+#if defined(__cpp_exceptions) && __cpp_exceptions || (defined(__EXCEPTIONS) && __EXCEPTIONS)
 
   class Clipper2Exception : public std::exception {
   public:
@@ -61,7 +61,7 @@ namespace Clipper2Lib
 
   static void DoError(int error_code)
   {
-#if __cpp_exceptions
+#if defined(__cpp_exceptions) && __cpp_exceptions || (defined(__EXCEPTIONS) && __EXCEPTIONS)
     switch (error_code)
     {
     case precision_error_i:


### PR DESCRIPTION
Under certain build configurations, MSVC may throw `error C4668: '__cpp_exceptions' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'` as there is no `__cpp_exceptions` in it - this should fix that.