### PR TITLE
Refactor C++ code to use index-based for loop for iterating over

### DIFF
--- a/CPP/Clipper2Lib/src/clipper.engine.cpp
+++ b/CPP/Clipper2Lib/src/clipper.engine.cpp
@@ -2928,8 +2928,10 @@ namespace Clipper2Lib {
       solutionOpen->reserve(outrec_list_.size());
     }
 
-    for (OutRec* outrec : outrec_list_)
+    // n.b.: outrec_list_ can grow during the loop, due to self-intersection handling in CleanCollinear
+    for (std::size_t i = 0; i < outrec_list_.size(); i++)
     {
+      OutRec* outrec = outrec_list_[i];
       if (outrec->pts == nullptr) continue;
 
       PathD path;


### PR DESCRIPTION
outrec_list.

The previous implementation used a range-based for loop, which is problematic since self-intersection handling in RemoveColinear() can add elements to outrec_list during the loop. If the std::vector size grows over previous capacity, it invalidates the iterators underlying the range-based for loop. This can result in a crash (or other undefined behaviour).