### PR TITLE
Mark 'what()' override

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.core.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.core.h
@@ -28,7 +28,7 @@ namespace Clipper2Lib
   public:
     explicit Clipper2Exception(const char* description) :
       m_descr(description) {}
-    virtual const char* what() const throw() { return m_descr.c_str(); }
+    virtual const char* what() const throw() override { return m_descr.c_str(); }
   private:
     std::string m_descr;
   };


### PR DESCRIPTION
Just a minor fix for a warning when compiling using gcc

The virtual function `what` overrides the built-in std::exception and should be marked as such.  Throws a warning when compiled with `-Wsuggest-override` otherwise