### PR TITLE
Rename Group CTOR parameters to avoid shadowing

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.offset.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.offset.h
@@ -36,8 +36,8 @@ private:
 		bool is_reversed = false;
 		JoinType join_type;
 		EndType end_type;
-		Group(const Paths64& paths, JoinType join_type, EndType end_type) :
-			paths_in(paths), join_type(join_type), end_type(end_type) {}
+		Group(const Paths64& _paths, JoinType _join_type, EndType _end_type) :
+			paths_in(_paths), join_type(_join_type), end_type(_end_type) {}
 	};
 
 	int   error_code_ = 0;


### PR DESCRIPTION
Minor change to avoid warnings in gcc.  

While the compiler can generally figure out that one `join_type` is a class variable and the other `join_type` is a parameter, GCC's `-Wshadow` warning will be thrown unless they are uniquely named