### PR TITLE
Include cstdint in clipper_core

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.core.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.core.h
@@ -10,6 +10,7 @@
 #ifndef CLIPPER_CORE_H
 #define CLIPPER_CORE_H
 
+#include <cstdint>
 #include <cstdlib>
 #include <cmath>
 #include <vector>


### PR DESCRIPTION
cstdint provides fixed-size integer types used in Clipper, e.g. int64_t. Some compilers include this header by reference from other headers but in GCC13, it is not included from the existing headers and needs to be explicitly included