### PR TITLE
perf: remove copy in `StripDuplicates`

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.core.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.core.h
@@ -558,38 +558,36 @@ namespace Clipper2Lib
   }
 
   template<typename T>
-  inline Path<T> StripDuplicates(const Path<T>& path, bool is_closed_path)
+  inline void StripDuplicates( Path<T>& path, bool is_closed_path)
   {
-    if (path.size() == 0) return Path<T>();
-    Path<T> result;
-    result.reserve(path.size());
-    typename Path<T>::const_iterator path_iter = path.cbegin();
-    Point<T> first_pt = *path_iter++, last_pt = first_pt;
-    result.push_back(first_pt);
-    for (; path_iter != path.cend(); ++path_iter)
+  if (path.size() == 0) return;
+  typename Path<T>::iterator path_iter = path.begin();
+  Point<T> first_pt = *path_iter++, last_pt = first_pt;
+  for (; path_iter != path.end();)
+  {
+    if (*path_iter == last_pt)
+      path_iter = path.erase(path_iter);
+    else
     {
-      if (*path_iter != last_pt)
-      {
-        last_pt = *path_iter;
-        result.push_back(last_pt);
-      }
+      last_pt = *path_iter;
+      ++path_iter;
     }
-    if (!is_closed_path) return result;
-    while (result.size() > 1 && result.back() == first_pt) result.pop_back();
-    return result;
+  }
+  if (is_closed_path)
+    while (path.size() > 1 && path.back() == first_pt) path.pop_back();
   }
 
   template<typename T>
-  inline Paths<T> StripDuplicates(const Paths<T>& paths, bool is_closed_path)
+  inline Paths<T> StripDuplicates( Paths<T>& paths, bool is_closed_path)
   {
-    Paths<T> result;
-    result.reserve(paths.size());
-    for (typename Paths<T>::const_iterator paths_citer = paths.cbegin();
-      paths_citer != paths.cend(); ++paths_citer)
+    //Paths<T> result;
+    //result.reserve(paths.size());
+    for (typename Paths<T>::iterator paths_citer = paths.begin();
+      paths_citer != paths.end(); ++paths_citer)
     {
-      result.push_back(StripDuplicates(*paths_citer, is_closed_path));
+      StripDuplicates(*paths_citer, is_closed_path);
     }
-    return result;
+    return paths;
   }
 
   // Miscellaneous ------------------------------------------------------------

--- a/CPP/Clipper2Lib/src/clipper.offset.cpp
+++ b/CPP/Clipper2Lib/src/clipper.offset.cpp
@@ -481,10 +481,11 @@ void ClipperOffset::DoGroupOffset(Group& group)
 	bool is_joined =
 		(end_type_ == EndType::Polygon) ||
 		(end_type_ == EndType::Joined);
-	Paths64::const_iterator path_iter;
-	for(path_iter = group.paths_in.cbegin(); path_iter != group.paths_in.cend(); ++path_iter)
+	Paths64::iterator path_iter;
+	for(path_iter = group.paths_in.begin(); path_iter != group.paths_in.end(); ++path_iter)
 	{
-		Path64 path = StripDuplicates(*path_iter, is_joined);
+		auto path = *path_iter;
+		StripDuplicates(path, is_joined);
 		Path64::size_type cnt = path.size();
 		if (cnt == 0 || ((cnt < 3) && group.end_type == EndType::Polygon)) 
 			continue;


### PR DESCRIPTION
Hi, Angus,

This is a great library and I hope that you do not mind me contributing some minor code.

In this pull request, I tried to avoid copy in `StripDuplicates`, and this can save some time for offset in my case.