### PR TITLE
Add googlebenchmark and improve the stripduplicates

### DIFF
--- a/CPP/BenchMark/CMakeLists.txt
+++ b/CPP/BenchMark/CMakeLists.txt
@@ -1,0 +1,35 @@
+# fetch the google benchmark library
+include(FetchContent)
+set(BENCHMARK_ENABLE_GTEST_TESTS OFF)
+set(BENCHMARK_ENABLE_TESTING OFF)
+message("start fetching the googlebenchmark")
+FetchContent_Declare(googlebenchmark
+        GIT_REPOSITORY https://github.com/google/benchmark.git
+        GIT_TAG v1.7.1
+) 
+
+FetchContent_MakeAvailable(
+        googlebenchmark)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+message("fetching is done")
+
+set(benchmark_srcs
+    StripDuplicateBenchmark.cpp
+    # more to add
+)
+
+# add each benchmark from the benchmark_srcs
+foreach(benchmark ${benchmark_srcs})
+    get_filename_component(benchmark_target ${benchmark} NAME_WE)
+
+    message(STATUS "${PROJECT_NAME} add benchmark ${benchmark_target}")
+    add_executable(${benchmark_target} ${benchmark})
+    target_include_directories(${benchmark_target}  PUBLIC
+        ${CMAKE_CURRENT_BINARY_DIR}/common/
+    )
+
+    target_link_libraries(${benchmark_target}
+        benchmark::benchmark
+        Clipper2
+    )
+endforeach()

--- a/CPP/BenchMark/CMakeLists.txt
+++ b/CPP/BenchMark/CMakeLists.txt
@@ -25,11 +25,12 @@ foreach(benchmark ${benchmark_srcs})
     message(STATUS "${PROJECT_NAME} add benchmark ${benchmark_target}")
     add_executable(${benchmark_target} ${benchmark})
     target_include_directories(${benchmark_target}  PUBLIC
-        ${CMAKE_CURRENT_BINARY_DIR}/common/
+        
     )
 
     target_link_libraries(${benchmark_target}
         benchmark::benchmark
         Clipper2
+        Clipper2utils
     )
 endforeach()

--- a/CPP/BenchMark/README.md
+++ b/CPP/BenchMark/README.md
@@ -1,0 +1,6 @@
+# google benchmark 
+this can be enabled by setting the option in the `CPP/CMakeLists.txt`
+
+```cmake
+option(USE_EXTERNAL_GBENCHMARK "Use the googlebenchmark" ON) 
+```

--- a/CPP/BenchMark/StripDuplicateBenchmark.cpp
+++ b/CPP/BenchMark/StripDuplicateBenchmark.cpp
@@ -1,6 +1,6 @@
 #include "benchmark/benchmark.h"
 #include "clipper2/clipper.h"
-#include "common/BenchMarkUtils.h"
+#include "Utils/CommonUtils.h"
 #include <iostream>
 
 static void CustomArguments(benchmark::internal::Benchmark *b) {

--- a/CPP/BenchMark/StripDuplicateBenchmark.cpp
+++ b/CPP/BenchMark/StripDuplicateBenchmark.cpp
@@ -1,0 +1,85 @@
+#include "benchmark/benchmark.h"
+#include "clipper2/clipper.h"
+#include "common/BenchMarkUtils.h"
+#include <iostream>
+
+static void CustomArguments(benchmark::internal::Benchmark *b) {
+  for (int i = 5; i <= 6; ++i)
+    for (int j = 5; j <= 6; j *= 8)
+      for (int k = 5; k <= 10; k++)
+        b->Args({i, j, k});
+}
+
+template <typename T>
+inline Clipper2Lib::Path<T>
+StripDuplicatesCopyVersion(const Clipper2Lib::Path<T> &path,
+                           bool is_closed_path) {
+  using namespace Clipper2Lib;
+  if (path.size() == 0)
+    return Path<T>();
+  Path<T> result;
+  result.reserve(path.size());
+  typename Path<T>::const_iterator path_iter = path.cbegin();
+  Point<T> first_pt = *path_iter++, last_pt = first_pt;
+  result.push_back(first_pt);
+  for (; path_iter != path.cend(); ++path_iter) {
+    if (*path_iter != last_pt) {
+      last_pt = *path_iter;
+      result.push_back(last_pt);
+    }
+  }
+  if (!is_closed_path)
+    return result;
+  while (result.size() > 1 && result.back() == first_pt)
+    result.pop_back();
+  return result;
+}
+
+template <typename T>
+inline Clipper2Lib::Paths<T>
+StripDuplicatesCopyVersion(const Clipper2Lib::Paths<T> &paths,
+                           bool is_closed_path) {
+  using namespace Clipper2Lib;
+  Paths<T> result;
+  result.reserve(paths.size());
+  for (typename Paths<T>::const_iterator paths_citer = paths.cbegin();
+       paths_citer != paths.cend(); ++paths_citer) {
+    result.push_back(StripDuplicatesCopyVersion(*paths_citer, is_closed_path));
+  }
+  return result;
+}
+
+static void BM_StripDuplicatesCopyVersion(benchmark::State &state) {
+  using namespace Clipper2Lib;
+  Paths64 op1;
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    int width = state.range(0);
+    int height = state.range(1);
+    int count = state.range(2);
+    op1.push_back(MakeRandomPoly(width, height, count));
+    state.ResumeTiming();
+    StripDuplicatesCopyVersion(op1, true);
+  }
+}
+
+static void BM_StripDuplicates(benchmark::State &state) {
+  using namespace Clipper2Lib;
+  Paths64 op1;
+  for (auto _ : state) {
+    state.PauseTiming();
+    int width = state.range(0);
+    int height = state.range(1);
+    int count = state.range(2);
+    op1.push_back(MakeRandomPoly(width, height, count));
+    state.ResumeTiming();
+    StripDuplicates(op1, true);
+  }
+}
+
+// Register the function as a benchmark
+BENCHMARK(BM_StripDuplicatesCopyVersion)->Apply(CustomArguments);
+BENCHMARK(BM_StripDuplicates)->Apply(CustomArguments);
+// Run the benchmark
+BENCHMARK_MAIN();

--- a/CPP/BenchMark/common/BenchMarkUtils.h
+++ b/CPP/BenchMark/common/BenchMarkUtils.h
@@ -1,0 +1,16 @@
+#include <cstdlib>
+#include "clipper2/clipper.h"
+#ifndef __BENCHMARKUTILS_H__
+#define __BENCHMARKUTILS_H__
+
+Clipper2Lib::Path64 MakeRandomPoly(int width, int height, unsigned vertCnt)
+{
+  using namespace Clipper2Lib;
+  Path64 result;
+  result.reserve(vertCnt);
+  for (unsigned i = 0; i < vertCnt; ++i)
+    result.push_back(Point64(std::rand() % width, std::rand() % height));
+  return result;
+}
+
+#endif

--- a/CPP/CMakeLists.txt
+++ b/CPP/CMakeLists.txt
@@ -84,6 +84,7 @@ if(CLIPPER2_UTILS OR CLIPPER2_TESTS OR CLIPPER2_EXAMPLES)
     Utils/ClipFileSave.h
     Utils/Timer.h
     Utils/Colors.h
+    Utils/CommonUtils.h
   )
   set(CLIPPER2_UTILS_SRC
     Utils/clipper.svg.cpp

--- a/CPP/CMakeLists.txt
+++ b/CPP/CMakeLists.txt
@@ -11,6 +11,7 @@ option(CLIPPER2_UTILS "Build utilities" ON)
 option(CLIPPER2_EXAMPLES "Build examples" ON)
 option(CLIPPER2_TESTS "Build tests" ON)
 option(USE_EXTERNAL_GTEST "Use system-wide installed GoogleTest" OFF)
+option(USE_EXTERNAL_GBENCHMARK "Use the googlebenchmark" OFF) 
 option(BUILD_SHARED_LIBS "Build shared libs" OFF)
 set(CLIPPER2_USINGZ "ON" CACHE STRING "Build Clipper2Z, either \"ON\" or \"OFF\" or \"ONLY\"")
 
@@ -234,6 +235,10 @@ endif()
   file(COPY ../Tests/PolytreeHoleOwner2.txt DESTINATION ${CMAKE_BINARY_DIR} FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ )
   file(COPY ../Tests/Lines.txt DESTINATION ${CMAKE_BINARY_DIR} FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ )
   file(COPY ../Tests/Polygons.txt DESTINATION ${CMAKE_BINARY_DIR} FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ )
+endif()
+
+if(USE_EXTERNAL_GBENCHMARK)
+  add_subdirectory(BenchMark)
 endif()
 
 set(CLIPPER2_PCFILES "")

--- a/CPP/Clipper2Lib/include/clipper2/clipper.core.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.core.h
@@ -560,21 +560,10 @@ namespace Clipper2Lib
   template<typename T>
   inline void StripDuplicates( Path<T>& path, bool is_closed_path)
   {
-  if (path.size() == 0) return;
-  typename Path<T>::iterator path_iter = path.begin();
-  Point<T> first_pt = *path_iter++, last_pt = first_pt;
-  for (; path_iter != path.end();)
-  {
-    if (*path_iter == last_pt)
-      path_iter = path.erase(path_iter);
-    else
-    {
-      last_pt = *path_iter;
-      ++path_iter;
-    }
-  }
-  if (is_closed_path)
-    while (path.size() > 1 && path.back() == first_pt) path.pop_back();
+    //https://stackoverflow.com/questions/1041620/whats-the-most-efficient-way-to-erase-duplicates-and-sort-a-vector#:~:text=Let%27s%20compare%20three%20approaches%3A
+    path.erase(std::unique(path.begin(), path.end()),path.end());
+    if (is_closed_path)
+      while (path.size() > 1 && path.back() == path.front()) path.pop_back();
   }
 
   template<typename T>

--- a/CPP/Utils/CommonUtils.h
+++ b/CPP/Utils/CommonUtils.h
@@ -1,7 +1,7 @@
 #include <cstdlib>
 #include "clipper2/clipper.h"
-#ifndef __BENCHMARKUTILS_H__
-#define __BENCHMARKUTILS_H__
+#ifndef __COMMONUTILS_H__
+#define __COMMONUTILS_H__
 
 Clipper2Lib::Path64 MakeRandomPoly(int width, int height, unsigned vertCnt)
 {


### PR DESCRIPTION
Hi, Angus, 

The stripeduplicate function is benchmarked against the previous version, and the result is shown below. 

![image](https://user-images.githubusercontent.com/21260868/229746339-98448ca7-0e6f-4b85-85f7-bb86a5013be0.png)

The googlebenchmark is introduced for benchmark, and this might be a handy tool for the other functions as well. Please kindly comment and i will change the pull request accordingly.