### PR TITLE
Added #include <stdint.h> to clipper.engine.h

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.engine.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.engine.h
@@ -13,6 +13,7 @@
 constexpr auto CLIPPER2_VERSION = "1.2.2";
 
 #include <cstdlib>
+#include <stdint.h>
 #include <iostream>
 #include <queue>
 #include <vector>


### PR DESCRIPTION
#  Summary:

This PR introduces a new include statement into the `clipper.engine.h` header file of the Clipper2Lib in the CPP project. Specifically, it adds `#include <stdint.h>`, which is a header file in the C standard library that allows for the use of integer types with specified widths. 

The lack of this include induced compilation failing with GCC12.