### PR TITLE
generate pkgconfig files with PCFILE_LIB_SUFFIX

### DIFF
--- a/CPP/CMakeLists.txt
+++ b/CPP/CMakeLists.txt
@@ -248,6 +248,7 @@ set(CLIPPER2_PCFILES "")
 foreach(lib ${CLIPPER2_LIBS})
   set(pc "${CMAKE_CURRENT_BINARY_DIR}/${lib}.pc")
   list(APPEND CLIPPER2_PCFILES ${pc})
+  string(REPLACE "Clipper2" "" PCFILE_LIB_SUFFIX "${lib}")
   CONFIGURE_FILE(Clipper2.pc.cmakein "${pc}" @ONLY)
 endforeach()
 


### PR DESCRIPTION
With `CLIPPER2_USINGZ=ON`, cmake generates two pkgconfig files:
- Clipper2.pc
- Clipper2Z.pc

But these files are same contents due to PCFILE_LIB_SUFFIX has no value.
```
Name: Clipper2@PCFILE_LIB_SUFFIX@
Libs: -L${libdir} -lClipper2@PCFILE_LIB_SUFFIX@
```

This PR try to solve it.
