### PR TITLE
Test bounding box width and height when checking if a path vanishes in clipper offset

### DIFF
--- a/CPP/Clipper2Lib/src/clipper.offset.cpp
+++ b/CPP/Clipper2Lib/src/clipper.offset.cpp
@@ -362,7 +362,8 @@ void ClipperOffset::OffsetPolygon(Group& group, Path64& path)
 	if ((a < 0) != (group_delta_ < 0)) 
 	{
 		Rect64 rec = GetBounds(path);
-		if (std::fabs(group_delta_) * 2 > rec.Width()) return;
+		double offsetMinDim = std::fabs(group_delta_) * 2;
+		if (offsetMinDim > rec.Width() || offsetMinDim > rec.Height()) return;
 	}
 
 	for (Path64::size_type j = 0, k = path.size() -1; j < path.size(); k = j, ++j)

--- a/CSharp/Clipper2Lib/Clipper.Offset.cs
+++ b/CSharp/Clipper2Lib/Clipper.Offset.cs
@@ -505,7 +505,8 @@ namespace Clipper2Lib
       if ((a < 0) != (_groupDelta < 0))
       {
         Rect64 rec = Clipper.GetBounds(path);
-        if (Math.Abs(_groupDelta) * 2 > rec.Width) return;
+        double offsetMinDim = Math.Abs(_groupDelta) * 2;
+        if (offsetMinDim > rec.Width || offsetMinDim > rec.Height) return;
       }
 
       group.outPath = new Path64();


### PR DESCRIPTION
When testing if a group is smaller than the offset (and thus will vanish in the output), not only test the bounding box width but also the height.

If either dimension is smaller than 2 times offset, the group will vanish when contracting. Suspected to fix issue #593.
All tests passed locally in C# and C++. Delphi is missing yet, I am not familiar with that language.