### PR TITLE
Rounding isn't necessary for the Z vallue here

### DIFF
--- a/CSharp/Clipper2Lib/Clipper.cs
+++ b/CSharp/Clipper2Lib/Clipper.cs
@@ -344,7 +344,7 @@ namespace Clipper2Lib
         X = (long) Math.Round(pt.X * scale, MidpointRounding.AwayFromZero),
         Y = (long) Math.Round(pt.Y * scale, MidpointRounding.AwayFromZero),
 #if USINGZ
-        Z = (long) Math.Round(pt.Z, MidpointRounding.AwayFromZero),
+        Z = pt.Z,
 #endif
       };
       return result;


### PR DESCRIPTION
This is redundant rounding (the Z value isn't being scaled and is already a long value). The compiler also complains about this call because Math.Round needs an explicit cast to decimal or double from the long, so this is resolved by discarding this rounding entirely.