### PR TITLE
Fix circular header file dependency

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.rectclip.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.rectclip.h
@@ -13,7 +13,6 @@
 #include <cstdlib>
 #include <vector>
 #include <queue>
-#include "clipper.h"
 #include "clipper.core.h"
 
 namespace Clipper2Lib


### PR DESCRIPTION
This pull request removes a redundant include of `clipper.h` in `clipper.rectclip.h` causing a circular dependency.

This causes a problem with static code analyzers like clang-tidy:
```
/builds/cyclops/owl.guard.cv/build/_deps/clipper2-src/CPP/Clipper2Lib/include/clipper2/clipper.rectclip.h:16:10: error: circular header file dependency detected while including 'clipper.h', please check the include path [misc-header-include-cycle,-warnings-as-errors]
   16 | #include "clipper.h"
      |          ^
/builds/cyclops/owl.guard.cv/build/_deps/clipper2-src/CPP/Clipper2Lib/include/clipper2/clipper.h:21:10: note: 'clipper.rectclip.h' included from here
   21 | #include "clipper.rectclip.h"
      |          ^
/builds/cyclops/owl.guard.cv/cyclops/packages/owlgeo/src/geom2d.cpp:10:10: note: 'clipper.h' included from here
   10 | #include <clipper2/clipper.h>
      |          ^
```