### PR TITLE
Fix simplification of open path

### DIFF
--- a/CPP/CMakeLists.txt
+++ b/CPP/CMakeLists.txt
@@ -213,6 +213,7 @@ endif()
     Tests/TestPolytreeUnion.cpp
     Tests/TestRandomPaths.cpp
     Tests/TestRectClip.cpp
+    Tests/TestSimplifyPath.cpp
     Tests/TestTrimCollinear.cpp
     Tests/TestWindows.cpp
   )

--- a/CPP/Clipper2Lib/include/clipper2/clipper.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.h
@@ -705,7 +705,8 @@ namespace Clipper2Lib {
         curr = next;
         next = GetNext(next, high, flags);
         prior2 = GetPrior(prior, high, flags);
-        distSqr[curr] = PerpendicDistFromLineSqrd(path[curr], path[prior], path[next]);
+        if (curr != high || isClosedPath)
+          distSqr[curr] = PerpendicDistFromLineSqrd(path[curr], path[prior], path[next]);
         if (prior != 0 || isClosedPath)
           distSqr[prior] = PerpendicDistFromLineSqrd(path[prior], path[prior2], path[curr]);
       }

--- a/CPP/Tests/TestSimplifyPath.cpp
+++ b/CPP/Tests/TestSimplifyPath.cpp
@@ -1,0 +1,14 @@
+#include "clipper2/clipper.h"
+#include <gtest/gtest.h>
+
+using namespace Clipper2Lib;
+
+TEST(Clipper2Tests, TestSimplifyPath) {
+
+  Path64 input1 = MakePath({
+      0,0, 1,1, 0,20, 0,21, 1,40, 0,41, 0,60, 0,61, 0,80, 1,81, 0,100
+  });
+  Path64 output1 = SimplifyPath(input1, 2, false);
+  EXPECT_EQ(Length(output1), 100);
+  EXPECT_EQ(output1.size(), 2);
+}


### PR DESCRIPTION
Simplification will sometimes remove the endpoint of an open path, since the squared distance of the endpoint can be recomputed.

See e.g. the attached test, where a slightly wiggly line between (0,0) and (0,100) is simplified to a straight line between (0,0) and (0,60).