### PR TITLE
CSharp Performance: don't decrease list capacities when reusing clipper objects

### DIFF
--- a/CSharp/Clipper2Lib/Clipper.Engine.cs
+++ b/CSharp/Clipper2Lib/Clipper.Engine.cs
@@ -242,12 +242,19 @@ namespace Clipper2Lib
       minimaList.Add(lm);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void EnsureCapacity<T>(this List<T> list, int minCapacity)
+    {
+      if(list.Capacity < minCapacity)
+        list.Capacity = minCapacity;
+    }
+
     internal static void AddPathsToVertexList(Paths64 paths, PathType polytype, bool isOpen,
       List<LocalMinima> minimaList, List<Vertex> vertexList)
     {
       int totalVertCnt = 0;
       foreach (Path64 path in paths) totalVertCnt += path.Count;
-      vertexList.Capacity = vertexList.Count + totalVertCnt;
+      vertexList.EnsureCapacity(vertexList.Count + totalVertCnt);
 
       foreach (Path64 path in paths)
       {
@@ -800,7 +807,7 @@ namespace Clipper2Lib
         _isSortedMinimaList = true;
       }
 
-      _scanlineList.Capacity = _minimaList.Count;
+      _scanlineList.EnsureCapacity(_minimaList.Count);
       for (int i = _minimaList.Count - 1; i >= 0; i--)
         _scanlineList.Add(_minimaList[i].vertex.pt.Y);
 
@@ -2982,8 +2989,8 @@ private void DoHorizontal(Active horz)
     {
       solutionClosed.Clear();
       solutionOpen.Clear();
-      solutionClosed.Capacity = _outrecList.Count;
-      solutionOpen.Capacity = _outrecList.Count;
+      solutionClosed.EnsureCapacity(_outrecList.Count);
+      solutionOpen.EnsureCapacity(_outrecList.Count);
       
       int i = 0;
       // _outrecList.Count is not static here because
@@ -3089,7 +3096,7 @@ private void DoHorizontal(Active horz)
       polytree.Clear();
       solutionOpen.Clear();
       if (_hasOpenPaths)
-        solutionOpen.Capacity = _outrecList.Count;
+        solutionOpen.EnsureCapacity(_outrecList.Count);
 
       int i = 0;
       // _outrecList.Count is not static here because
@@ -3354,10 +3361,10 @@ private void DoHorizontal(Active horz)
       ClearSolutionOnly();
       if (!success) return false;
 
-      solutionClosed.Capacity = solClosed64.Count;
+      solutionClosed.EnsureCapacity(solClosed64.Count);
       foreach (Path64 path in solClosed64)
         solutionClosed.Add(Clipper.ScalePathD(path, _invScale));
-      solutionOpen.Capacity = solOpen64.Count;
+      solutionOpen.EnsureCapacity(solOpen64.Count);
       foreach (Path64 path in solOpen64)
         solutionOpen.Add(Clipper.ScalePathD(path, _invScale));
 
@@ -3394,7 +3401,7 @@ private void DoHorizontal(Active horz)
       if (!success) return false;
       if (oPaths.Count > 0)
       {
-        openPaths.Capacity = oPaths.Count;        
+        openPaths.EnsureCapacity(oPaths.Count);
         foreach (Path64 path in oPaths)
           openPaths.Add(Clipper.ScalePathD(path, _invScale));
       }

--- a/CSharp/Clipper2Lib/Clipper.Offset.cs
+++ b/CSharp/Clipper2Lib/Clipper.Offset.cs
@@ -162,7 +162,7 @@ namespace Clipper2Lib
     {
       _solution.Clear();
       if (_groupList.Count == 0) return;
-      _solution.Capacity = CalcSolutionCapacity();
+      _solution.EnsureCapacity(CalcSolutionCapacity());
 
       // make sure the offset delta is significant
       if (Math.Abs(delta) < 0.5)
@@ -257,7 +257,7 @@ namespace Clipper2Lib
 
     internal static void GetMultiBounds(Paths64 paths, List<Rect64> boundsList)
     {
-      boundsList.Capacity = paths.Count;
+      boundsList.EnsureCapacity(paths.Count);
       foreach (Path64 path in paths)
       {
         if (path.Count < 1)
@@ -545,7 +545,7 @@ namespace Clipper2Lib
     {
       int cnt = path.Count;
       _normals.Clear();
-      _normals.Capacity = cnt;
+      _normals.EnsureCapacity(cnt);
 
       for (int i = 0; i < cnt - 1; i++)
         _normals.Add(GetUnitNormal(path[i], path[i + 1]));


### PR DESCRIPTION
CSharp Performance: when reusing clipper objects, currently clipper sets the internal lists capacity, even if the capacity is already sufficient. This causes C#  to drop the currently allocated array and create a new, smaller one (If clipper is not reused this is fine).

This merge request contains changes that check if the capacity is sufficient before setting it to reduce allocations.

I have conducted a benchmark (using BenchmarkDotNet) of my application that reuses clipper objects. This small change reduces allocations by 15% and also slightly improves runtimes.

| Method                         | Scenario             | solutionsToCalc | Mean    | Error    | StdDev   | Gen0       | Gen1      | Allocated |
|------------------------------- |--------------------- |---------------- |--------:|---------:|---------:|-----------:|----------:|----------:|
| NestScenarioWithStartHeuristic | 3DIPP-Instance-01259 | 4               | 6.320 s | 0.1240 s | 0.1656 s | 14000.0000 | 1000.0000 |  25.73 GB |
| NestScenarioWithStartHeuristic - no Capacity decrease | 3DIPP-Instance-01259 | 4               | 6.221 s | 0.1122 s | 0.1050 s | 12000.0000 | 1000.0000 |  21.93 GB |