### PR TITLE
Let CMake automatically clone the googletest repo, so that users do not need to do it separately

### DIFF
--- a/.github/workflows/actions_cpp.yml
+++ b/.github/workflows/actions_cpp.yml
@@ -10,10 +10,6 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '16'
-    - name: Get GoogleTest
-      run: |
-        cd CPP/Tests
-        git clone https://github.com/google/googletest
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2      
     - name: Build
@@ -33,10 +29,6 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '16'
-    - name: Get GoogleTest
-      run: |
-        cd CPP/Tests
-        git clone https://github.com/google/googletest
     - name: Build
       run: |
         mkdir CPP/build
@@ -54,10 +46,6 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '16'
-    - name: Get GoogleTest
-      run: |
-        cd CPP/Tests
-        git clone https://github.com/google/googletest
     - name: Install gcc 11
       run: |
         sudo apt update
@@ -80,10 +68,6 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '16'
-    - name: Get GoogleTest
-      run: |
-        cd CPP/Tests
-        git clone https://github.com/google/googletest
     - name: Build
       run: |
         export CC=/usr/bin/clang
@@ -103,10 +87,6 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '16'
-    - name: Get GoogleTest
-      run: |
-        cd CPP/Tests
-        git clone https://github.com/google/googletest
     - name: Install clang 13
       run: |
         wget https://apt.llvm.org/llvm.sh
@@ -131,10 +111,6 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '16'
-    - name: Get GoogleTest
-      run: |
-        cd CPP/Tests
-        git clone https://github.com/google/googletest
     - name: Build
       run: |
         mkdir CPP/build

--- a/CPP/CMakeLists.txt
+++ b/CPP/CMakeLists.txt
@@ -210,7 +210,10 @@ if(USE_EXTERNAL_GTEST)
   find_package(GTest REQUIRED)
 else()
   include(GoogleTest)
-
+  execute_process(
+    COMMAND "git" "clone" "https://github.com/google/googletest"
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Tests
+  )
   add_subdirectory("${PROJECT_SOURCE_DIR}/Tests/googletest/")
   set_target_properties(gtest gtest_main PROPERTIES FOLDER GTest)
 endif()


### PR DESCRIPTION
Resolves #809