### PR TITLE
Restore default constructors

### DIFF
--- a/CSharp/Clipper2Lib/Clipper.Core.cs
+++ b/CSharp/Clipper2Lib/Clipper.Core.cs
@@ -473,6 +473,7 @@ namespace Clipper2Lib
 
   public class Path64 : List<Point64> 
   {
+    public Path64() : base() { }
     public Path64(int capacity = 0) : base(capacity) { }
     public Path64(IEnumerable<Point64> path) : base(path) { }
     public override string ToString()
@@ -486,6 +487,7 @@ namespace Clipper2Lib
 
   public class Paths64 : List<Path64>
   {
+    public Paths64() : base() { }
     public Paths64(int capacity = 0) : base(capacity) { }
     public Paths64(IEnumerable<Path64> paths) : base(paths) { }
     public override string ToString()
@@ -499,6 +501,7 @@ namespace Clipper2Lib
 
   public class PathD : List<PointD>
   {
+    public PathD() : base() { }
     public PathD(int capacity = 0) : base(capacity) { }
     public PathD(IEnumerable<PointD> path) : base(path) { }
     public string ToString(int precision = 2)
@@ -512,6 +515,7 @@ namespace Clipper2Lib
 
   public class PathsD : List<PathD>
   {
+    public PathsD() : base() { }
     public PathsD(int capacity = 0) : base(capacity) { }
     public PathsD(IEnumerable<PathD> paths) : base(paths) { }
     public string ToString(int precision = 2)


### PR DESCRIPTION
Required for hash functions to work, discovered in real world usage.