### PR TITLE
`IsCollinear`: detect and handle integer multiplication wrapping (version 2)

### DIFF
--- a/CPP/Tests/TestIsCollinear.cpp
+++ b/CPP/Tests/TestIsCollinear.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include "clipper2/clipper.core.h"
+#include "clipper2/clipper.h"
 
 TEST(Clipper2Tests, TestIsCollinear) {
   // a large integer not representable by double
@@ -10,4 +10,20 @@ TEST(Clipper2Tests, TestIsCollinear) {
   const Clipper2Lib::Point64 pt2(i * 10, i * 100);
 
   EXPECT_TRUE(IsCollinear(pt1, sharedPt, pt2));
+}
+
+TEST(Clipper2Tests, TestIsCollinear2) {
+  // see https://github.com/AngusJohnson/Clipper2/issues/831
+  const int64_t i = 0x4000000000000;
+  const Clipper2Lib::Path64 subject = {
+    Clipper2Lib::Point64(-i, -i),
+    Clipper2Lib::Point64( i, -i),
+    Clipper2Lib::Point64(-i,  i),
+    Clipper2Lib::Point64( i,  i)
+  };
+  Clipper2Lib::Clipper64 clipper;
+  clipper.AddSubject({ subject });
+  Clipper2Lib::Paths64 solution;
+  clipper.Execute(Clipper2Lib::ClipType::Union, Clipper2Lib::FillRule::EvenOdd, solution);
+  EXPECT_EQ(solution.size(), 2);
 }


### PR DESCRIPTION
This is similar to #832, but tries to avoid branching and division.

@here-abarany, what do you think?