### PR TITLE
Use compiler-provided `__int128` type on clang and gcc

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.core.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.core.h
@@ -695,6 +695,11 @@ namespace Clipper2Lib
   // returns true if (and only if) a * b == c * d
   inline bool ProductsAreEqual(int64_t a, int64_t b, int64_t c, int64_t d)
   {
+#if (defined(__clang__) || defined(__GNUC__)) && UINTPTR_MAX >= UINT64_MAX
+    const auto ab = static_cast<__int128_t>(a) * static_cast<__int128_t>(b);
+    const auto cd = static_cast<__int128_t>(c) * static_cast<__int128_t>(d);
+    return ab == cd;
+#else
     // nb: unsigned values needed for calculating overflow carry
     const auto abs_a = static_cast<uint64_t>(std::abs(a));
     const auto abs_b = static_cast<uint64_t>(std::abs(b));
@@ -709,6 +714,7 @@ namespace Clipper2Lib
     const auto sign_cd = TriSign(c) * TriSign(d);
 
     return abs_ab == abs_cd && sign_ab == sign_cd;
+#endif
   }
 
   template <typename T>


### PR DESCRIPTION
(when the target architecture is at least 64-bit)

Apparently this should be faster on modern compilers. In addition, it ought to be obvious that it gives the correct answer. :)