### PR TITLE
First step for habitrary types Clipper2

### DIFF
--- a/CPP/CMakeLists.txt
+++ b/CPP/CMakeLists.txt
@@ -20,7 +20,7 @@ option(USE_EXTERNAL_GBENCHMARK "Use the googlebenchmark" OFF)
 option(BUILD_SHARED_LIBS "Build shared libs" OFF)
 set(CLIPPER2_USINGZ "ON" CACHE STRING "Build Clipper2Z, either \"ON\" or \"OFF\" or \"ONLY\"")
 
-# CLIPPER2_MAX_DECIMAL_PRECISION: maximum decimal precision when scaling PathsD to Paths64.
+# CLIPPER2_MAX_DECIMAL_PRECISION: maximum decimal precision when scaling PathsS to PathsI.
 # Caution: excessive scaling will increase the likelihood of integer overflow errors.
 set(CLIPPER2_MAX_DECIMAL_PRECISION 8 CACHE STRING "Maximum decimal precision range")
 

--- a/CPP/Clipper2Lib/include/clipper2/clipper.engine.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.engine.h
@@ -52,30 +52,30 @@ namespace Clipper2Lib {
 	}
 
 	struct Vertex {
-		Point64 pt;
+		PointI pt;
 		Vertex* next = nullptr;
 		Vertex* prev = nullptr;
 		VertexFlags flags = VertexFlags::None;
 	};
 
 	struct OutPt {
-		Point64 pt;
+		PointI pt;
 		OutPt*	next = nullptr;
 		OutPt*	prev = nullptr;
 		OutRec* outrec;
 		HorzSegment* horz = nullptr;
 
-		OutPt(const Point64& pt_, OutRec* outrec_): pt(pt_), outrec(outrec_) {
+		OutPt(const PointI& pt_, OutRec* outrec_): pt(pt_), outrec(outrec_) {
 			next = this;
 			prev = this;
 		}
 	};
 
 	class PolyPath;
-	class PolyPath64;
-	class PolyPathD;
-	using PolyTree64 = PolyPath64;
-	using PolyTreeD = PolyPathD;
+	class PolyPathI;
+	class PolyPathS;
+	using PolyTreeI = PolyPathI;
+	using PolyTreeD = PolyPathS;
 
 	struct OutRec;
 	typedef std::vector<OutRec*> OutRecList;
@@ -91,8 +91,8 @@ namespace Clipper2Lib {
 		PolyPath* polypath = nullptr;
 		OutRecList* splits = nullptr;
 		OutRec* recursive_split = nullptr;
-		Rect64 bounds = {};
-		Path64 path;
+		RectI bounds = {};
+		PathI path;
 		bool is_open = false;
 
 		~OutRec() {
@@ -108,10 +108,10 @@ namespace Clipper2Lib {
 	///////////////////////////////////////////////////////////////////
 
 	struct Active {
-		Point64 bot;
-		Point64 top;
-		int64_t curr_x = 0;		//current (updated at every new scanline)
-		double dx = 0.0;
+		PointI bot;
+		PointI top;
+		Integer curr_x = 0;		//current (updated at every new scanline)
+		Scalar dx = 0.0;
 		int wind_dx = 1;			//1 or -1 depending on winding direction
 		int wind_cnt = 0;
 		int wind_cnt2 = 0;		//winding count of the opposite polytype
@@ -143,11 +143,11 @@ namespace Clipper2Lib {
 	};
 
 	struct IntersectNode {
-		Point64 pt;
+		PointI pt;
 		Active* edge1;
 		Active* edge2;
-		IntersectNode() : pt(Point64(0,0)), edge1(NULL), edge2(NULL) {}
-			IntersectNode(Active* e1, Active* e2, Point64& pt_) :
+		IntersectNode() : pt(PointI(0,0)), edge1(NULL), edge2(NULL) {}
+			IntersectNode(Active* e1, Active* e2, PointI& pt_) :
 			pt(pt_), edge1(e1), edge2(e2) {}
 	};
 
@@ -167,11 +167,11 @@ namespace Clipper2Lib {
 	};
 
 #ifdef USINGZ
-		typedef std::function<void(const Point64& e1bot, const Point64& e1top,
-		const Point64& e2bot, const Point64& e2top, Point64& pt)> ZCallback64;
+		typedef std::function<void(const PointI& e1bot, const PointI& e1top,
+		const PointI& e2bot, const PointI& e2top, PointI& pt)> ZCallbackI;
 
-	typedef std::function<void(const PointD& e1bot, const PointD& e1top,
-		const PointD& e2bot, const PointD& e2top, PointD& pt)> ZCallbackD;
+	typedef std::function<void(const PointS& e1bot, const PointS& e1top,
+		const PointS& e2bot, const PointS& e2top, PointS& pt)> ZCallbackS;
 #endif
 
 	typedef std::vector<HorzSegment> HorzSegmentList;
@@ -179,18 +179,18 @@ namespace Clipper2Lib {
 	typedef std::vector<LocalMinima_ptr> LocalMinimaList;
 	typedef std::vector<IntersectNode> IntersectNodeList;
 
-	// ReuseableDataContainer64 ------------------------------------------------
+	// ReuseableDataContainerI ------------------------------------------------
 
-	class ReuseableDataContainer64 {
+	class ReuseableDataContainerI {
 	private:
 		friend class ClipperBase;
 		LocalMinimaList minima_list_;
 		std::vector<Vertex*> vertex_lists_;
 		void AddLocMin(Vertex& vert, PathType polytype, bool is_open);
 	public:
-		virtual ~ReuseableDataContainer64();
+		virtual ~ReuseableDataContainerI();
 		void Clear();
-		void AddPaths(const Paths64& paths, PathType polytype, bool is_open);
+		void AddPaths(const PathsI& paths, PathType polytype, bool is_open);
 	};
 
 	// ClipperBase -------------------------------------------------------------
@@ -200,7 +200,7 @@ namespace Clipper2Lib {
 		ClipType cliptype_ = ClipType::None;
 		FillRule fillrule_ = FillRule::EvenOdd;
 		FillRule fillpos = FillRule::Positive;
-		int64_t bot_y_ = 0;
+		Integer bot_y_ = 0;
 		bool minima_list_sorted_ = false;
 		bool using_polytree_ = false;
 		Active* actives_ = nullptr;
@@ -208,14 +208,14 @@ namespace Clipper2Lib {
 		LocalMinimaList minima_list_;		//pointers in case of memory reallocs
 		LocalMinimaList::iterator current_locmin_iter_;
 		std::vector<Vertex*> vertex_lists_;
-		std::priority_queue<int64_t> scanline_list_;
+		std::priority_queue<Integer> scanline_list_;
 		IntersectNodeList intersect_nodes_;
     HorzSegmentList horz_seg_list_;
 		std::vector<HorzJoin> horz_join_list_;
 		void Reset();
-		inline void InsertScanline(int64_t y);
-		inline bool PopScanline(int64_t &y);
-		inline bool PopLocalMinima(int64_t y, LocalMinima*& local_minima);
+		inline void InsertScanline(Integer y);
+		inline bool PopScanline(Integer &y);
+		inline bool PopLocalMinima(Integer y, LocalMinima*& local_minima);
 		void DisposeAllOutRecs();
 		void DisposeVerticesAndLocalMinima();
 		void DeleteEdges(Active*& e);
@@ -224,29 +224,29 @@ namespace Clipper2Lib {
 		inline bool IsContributingOpen(const Active &e) const;
 		void SetWindCountForClosedPathEdge(Active &edge);
 		void SetWindCountForOpenPathEdge(Active &e);
-		void InsertLocalMinimaIntoAEL(int64_t bot_y);
+		void InsertLocalMinimaIntoAEL(Integer bot_y);
 		void InsertLeftEdge(Active &e);
 		inline void PushHorz(Active &e);
 		inline bool PopHorz(Active *&e);
-		inline OutPt* StartOpenPath(Active &e, const Point64& pt);
+		inline OutPt* StartOpenPath(Active &e, const PointI& pt);
 		inline void UpdateEdgeIntoAEL(Active *e);
-		void IntersectEdges(Active &e1, Active &e2, const Point64& pt);
+		void IntersectEdges(Active &e1, Active &e2, const PointI& pt);
 		inline void DeleteFromAEL(Active &e);
-		inline void AdjustCurrXAndCopyToSEL(const int64_t top_y);
-		void DoIntersections(const int64_t top_y);
-		void AddNewIntersectNode(Active &e1, Active &e2, const int64_t top_y);
-		bool BuildIntersectList(const int64_t top_y);
+		inline void AdjustCurrXAndCopyToSEL(const Integer top_y);
+		void DoIntersections(const Integer top_y);
+		void AddNewIntersectNode(Active &e1, Active &e2, const Integer top_y);
+		bool BuildIntersectList(const Integer top_y);
 		void ProcessIntersectList();
 		void SwapPositionsInAEL(Active& edge1, Active& edge2);
 		OutRec* NewOutRec();
-		OutPt* AddOutPt(const Active &e, const Point64& pt);
+		OutPt* AddOutPt(const Active &e, const PointI& pt);
 		OutPt* AddLocalMinPoly(Active &e1, Active &e2,
-			const Point64& pt, bool is_new = false);
-		OutPt* AddLocalMaxPoly(Active &e1, Active &e2, const Point64& pt);
+			const PointI& pt, bool is_new = false);
+		OutPt* AddLocalMaxPoly(Active &e1, Active &e2, const PointI& pt);
 		void DoHorizontal(Active &horz);
 		bool ResetHorzDirection(const Active &horz, const Vertex* max_vertex,
-			int64_t &horz_left, int64_t &horz_right);
-		void DoTopOfScanbeam(const int64_t top_y);
+			Integer &horz_left, Integer &horz_right);
+		void DoTopOfScanbeam(const Integer top_y);
 		Active *DoMaxima(Active &e);
 		void JoinOutrecPaths(Active &e1, Active &e2);
 		void FixSelfIntersects(OutRec* outrec);
@@ -256,11 +256,11 @@ namespace Clipper2Lib {
 		void ConvertHorzSegsToJoins();
 		void ProcessHorzJoins();
 
-		void Split(Active& e, const Point64& pt);
+		void Split(Active& e, const PointI& pt);
 		inline void CheckJoinLeft(Active& e,
-			const Point64& pt, bool check_curr_x = false);
+			const PointI& pt, bool check_curr_x = false);
 		inline void CheckJoinRight(Active& e,
-			const Point64& pt, bool check_curr_x = false);
+			const PointI& pt, bool check_curr_x = false);
 	protected:
 		bool preserve_collinear_ = true;
 		bool reverse_solution_ = false;
@@ -274,12 +274,12 @@ namespace Clipper2Lib {
 		bool CheckSplitOwner(OutRec* outrec, OutRecList* splits);
 		void RecursiveCheckOwners(OutRec* outrec, PolyPath* polypath);
 #ifdef USINGZ
-		ZCallback64 zCallback_ = nullptr;
-		void SetZ(const Active& e1, const Active& e2, Point64& pt);
+		ZCallbackI zCallback_ = nullptr;
+		void SetZ(const Active& e1, const Active& e2, PointI& pt);
 #endif
 		void CleanUp();  // unlike Clear, CleanUp preserves added paths
-		void AddPath(const Path64& path, PathType polytype, bool is_open);
-		void AddPaths(const Paths64& paths, PathType polytype, bool is_open);
+		void AddPath(const PathI& path, PathType polytype, bool is_open);
+		void AddPaths(const PathsI& paths, PathType polytype, bool is_open);
 	public:
 		virtual ~ClipperBase();
 		int ErrorCode() const { return error_code_; };
@@ -288,9 +288,9 @@ namespace Clipper2Lib {
 		void ReverseSolution(bool val) { reverse_solution_ = val; };
 		bool ReverseSolution() const { return reverse_solution_; };
 		void Clear();
-		void AddReuseableData(const ReuseableDataContainer64& reuseable_data);
+		void AddReuseableData(const ReuseableDataContainerI& reuseable_data);
 #ifdef USINGZ
-		int64_t DefaultZ = 0;
+		Integer DefaultZ = 0;
 #endif
 	};
 
@@ -319,7 +319,7 @@ namespace Clipper2Lib {
 			return result;
 		}
 
-		virtual PolyPath* AddChild(const Path64& path) = 0;
+		virtual PolyPath* AddChild(const PathI& path) = 0;
 
 		virtual void Clear() = 0;
 		virtual size_t Count() const { return 0; }
@@ -334,36 +334,36 @@ namespace Clipper2Lib {
 		}
 	};
 
-	typedef typename std::vector<std::unique_ptr<PolyPath64>> PolyPath64List;
-	typedef typename std::vector<std::unique_ptr<PolyPathD>>  PolyPathDList;
+	typedef typename std::vector<std::unique_ptr<PolyPathI>> PolyPathIList;
+	typedef typename std::vector<std::unique_ptr<PolyPathS>> PolyPathSList;
 
-	class PolyPath64 : public PolyPath {
+	class PolyPathI : public PolyPath {
 	private:
-		PolyPath64List childs_;
-		Path64 polygon_;
+		PolyPathIList childs_;
+		PathI polygon_;
 	public:
-		explicit PolyPath64(PolyPath64* parent = nullptr) : PolyPath(parent) {}
+		explicit PolyPathI(PolyPathI* parent = nullptr) : PolyPath(parent) {}
 
-		~PolyPath64() {
+		~PolyPathI() {
 			childs_.resize(0);
 		}
 
-		PolyPath64* operator [] (size_t index) const
+		PolyPathI* operator [] (size_t index) const
 		{
 			return childs_[index].get(); //std::unique_ptr
 		}
 
-		PolyPath64* Child(size_t index) const
+		PolyPathI* Child(size_t index) const
 		{
 			return childs_[index].get();
 		}
 
-		PolyPath64List::const_iterator begin() const { return childs_.cbegin(); }
-		PolyPath64List::const_iterator end() const { return childs_.cend(); }
+		PolyPathIList::const_iterator begin() const { return childs_.cbegin(); }
+		PolyPathIList::const_iterator end() const { return childs_.cend(); }
 
-		PolyPath64* AddChild(const Path64& path) override
+		PolyPathI* AddChild(const PathI& path) override
 		{
-			auto p = std::make_unique<PolyPath64>(this);
+			auto p = std::make_unique<PolyPathI>(this);
 			auto* result = childs_.emplace_back(std::move(p)).get();
 			result->polygon_ = path;
 			return result;
@@ -379,61 +379,61 @@ namespace Clipper2Lib {
 			return childs_.size();
 		}
 
-		const Path64& Polygon() const { return polygon_; };
+		const PathI& Polygon() const { return polygon_; };
 
-		double Area() const
+		Scalar Area() const
 		{
 			return std::accumulate(childs_.cbegin(), childs_.cend(),
-				Clipper2Lib::Area<int64_t>(polygon_),
-				[](double a, const auto& child) {return a + child->Area(); });
+				Clipper2Lib::Area<Integer>(polygon_),
+				[](Scalar a, const auto& child) {return a + child->Area(); });
 		}
 
 	};
 
-	class PolyPathD : public PolyPath {
+	class PolyPathS : public PolyPath {
 	private:
-		PolyPathDList childs_;
-		double scale_;
-		PathD polygon_;
+		PolyPathSList childs_;
+		Scalar scale_;
+		PathS polygon_;
 	public:
-		explicit PolyPathD(PolyPathD* parent = nullptr) : PolyPath(parent)
+		explicit PolyPathS(PolyPathS* parent = nullptr) : PolyPath(parent)
 		{
-			scale_ = parent ? parent->scale_ : 1.0;
+			scale_ = parent ? parent->scale_ : (Scalar)1.0;
 		}
 
-		~PolyPathD() {
+		~PolyPathS() {
 			childs_.resize(0);
 		}
 
-		PolyPathD* operator [] (size_t index) const
+		PolyPathS* operator [] (size_t index) const
 		{
 			return childs_[index].get();
 		}
 
-		PolyPathD* Child(size_t index) const
+		PolyPathS* Child(size_t index) const
 		{
 			return childs_[index].get();
 		}
 
-		PolyPathDList::const_iterator begin() const { return childs_.cbegin(); }
-		PolyPathDList::const_iterator end() const { return childs_.cend(); }
+		PolyPathSList::const_iterator begin() const { return childs_.cbegin(); }
+		PolyPathSList::const_iterator end() const { return childs_.cend(); }
 
-		void SetScale(double value) { scale_ = value; }
-		double Scale() const { return scale_; }
+		void SetScale(Scalar value) { scale_ = value; }
+		Scalar Scale() const { return scale_; }
 
-		PolyPathD* AddChild(const Path64& path) override
+		PolyPathS* AddChild(const PathI& path) override
 		{
 			int error_code = 0;
-			auto p = std::make_unique<PolyPathD>(this);
-			PolyPathD* result = childs_.emplace_back(std::move(p)).get();
-			result->polygon_ = ScalePath<double, int64_t>(path, scale_, error_code);
+			auto p = std::make_unique<PolyPathS>(this);
+			PolyPathS* result = childs_.emplace_back(std::move(p)).get();
+			result->polygon_ = ScalePath<Scalar, Integer>(path, scale_, error_code);
 			return result;
 		}
 
-		PolyPathD* AddChild(const PathD& path)
+		PolyPathS* AddChild(const PathS& path)
 		{
-			auto p = std::make_unique<PolyPathD>(this);
-			PolyPathD* result = childs_.emplace_back(std::move(p)).get();
+			auto p = std::make_unique<PolyPathS>(this);
+			PolyPathS* result = childs_.emplace_back(std::move(p)).get();
 			result->polygon_ = path;
 			return result;
 		}
@@ -448,111 +448,111 @@ namespace Clipper2Lib {
 			return childs_.size();
 		}
 
-		const PathD& Polygon() const { return polygon_; };
+		const PathS& Polygon() const { return polygon_; };
 
-		double Area() const
+		Scalar Area() const
 		{
 			return std::accumulate(childs_.begin(), childs_.end(),
-				Clipper2Lib::Area<double>(polygon_),
-				[](double a, const auto& child) {return a + child->Area(); });
+				Clipper2Lib::Area<Scalar>(polygon_),
+				[](Scalar a, const auto& child) {return a + child->Area(); });
 		}
 	};
 
-	class Clipper64 : public ClipperBase
+	class ClipperI : public ClipperBase
 	{
 	private:
-		void BuildPaths64(Paths64& solutionClosed, Paths64* solutionOpen);
-		void BuildTree64(PolyPath64& polytree, Paths64& open_paths);
+		void BuildPathsI(PathsI& solutionClosed, PathsI* solutionOpen);
+		void BuildTreeI(PolyPathI& polytree, PathsI& open_paths);
 	public:
 #ifdef USINGZ
-		void SetZCallback(ZCallback64 cb) { zCallback_ = cb; }
+		void SetZCallback(ZCallbackI cb) { zCallback_ = cb; }
 #endif
 
-		void AddSubject(const Paths64& subjects)
+		void AddSubject(const PathsI& subjects)
 		{
 			AddPaths(subjects, PathType::Subject, false);
 		}
-		void AddOpenSubject(const Paths64& open_subjects)
+		void AddOpenSubject(const PathsI& open_subjects)
 		{
 			AddPaths(open_subjects, PathType::Subject, true);
 		}
-		void AddClip(const Paths64& clips)
+		void AddClip(const PathsI& clips)
 		{
 			AddPaths(clips, PathType::Clip, false);
 		}
 
 		bool Execute(ClipType clip_type,
-			FillRule fill_rule, Paths64& closed_paths)
+			FillRule fill_rule, PathsI& closed_paths)
 		{
-			Paths64 dummy;
+			PathsI dummy;
 			return Execute(clip_type, fill_rule, closed_paths, dummy);
 		}
 
 		bool Execute(ClipType clip_type, FillRule fill_rule,
-			Paths64& closed_paths, Paths64& open_paths)
+			PathsI& closed_paths, PathsI& open_paths)
 		{
 			closed_paths.clear();
 			open_paths.clear();
 			if (ExecuteInternal(clip_type, fill_rule, false))
-					BuildPaths64(closed_paths, &open_paths);
+					BuildPathsI(closed_paths, &open_paths);
 			CleanUp();
 			return succeeded_;
 		}
 
-		bool Execute(ClipType clip_type, FillRule fill_rule, PolyTree64& polytree)
+		bool Execute(ClipType clip_type, FillRule fill_rule, PolyTreeI& polytree)
 		{
-			Paths64 dummy;
+			PathsI dummy;
 			return Execute(clip_type, fill_rule, polytree, dummy);
 		}
 
 		bool Execute(ClipType clip_type,
-			FillRule fill_rule, PolyTree64& polytree, Paths64& open_paths)
+			FillRule fill_rule, PolyTreeI& polytree, PathsI& open_paths)
 		{
 			if (ExecuteInternal(clip_type, fill_rule, true))
 			{
 				open_paths.clear();
 				polytree.Clear();
-				BuildTree64(polytree, open_paths);
+				BuildTreeI(polytree, open_paths);
 			}
 			CleanUp();
 			return succeeded_;
 		}
 	};
 
-	class ClipperD : public ClipperBase {
+	class ClipperS : public ClipperBase {
 	private:
-		double scale_ = 1.0, invScale_ = 1.0;
+		Scalar scale_ = (Scalar)1.0, invScale_ = (Scalar)1.0;
 #ifdef USINGZ
-		ZCallbackD zCallbackD_ = nullptr;
+		ZCallbackS zCallbackD_ = nullptr;
 #endif
-		void BuildPathsD(PathsD& solutionClosed, PathsD* solutionOpen);
-		void BuildTreeD(PolyPathD& polytree, PathsD& open_paths);
+		void BuildPathsS(PathsS& solutionClosed, PathsS* solutionOpen);
+		void BuildTreeS(PolyPathS& polytree, PathsS& open_paths);
 	public:
-		explicit ClipperD(int precision = 2) : ClipperBase()
+		explicit ClipperS(int precision = 2) : ClipperBase()
 		{
 			CheckPrecisionRange(precision, error_code_);
 			// to optimize scaling / descaling precision
-			// set the scale to a power of double's radix (2) (#25)
-			scale_ = std::pow(std::numeric_limits<double>::radix,
-				std::ilogb(std::pow(10, precision)) + 1);
-			invScale_ = 1 / scale_;
+			// set the scale to a power of Scalar's radix (2) (#25)
+			scale_ = (Scalar)std::pow((Scalar)std::numeric_limits<Scalar>::radix,
+				(Scalar)std::ilogb((Scalar)std::pow(10, precision)) + (Scalar)1);
+			invScale_ = (Scalar)1 / scale_;
 		}
 
 #ifdef USINGZ
-		void SetZCallback(ZCallbackD cb) { zCallbackD_ = cb; };
+		void SetZCallback(ZCallbackS cb) { zCallbackD_ = cb; };
 
-		void ZCB(const Point64& e1bot, const Point64& e1top,
-			const Point64& e2bot, const Point64& e2top, Point64& pt)
+		void ZCB(const PointI& e1bot, const PointI& e1top,
+			const PointI& e2bot, const PointI& e2top, PointI& pt)
 		{
 			// de-scale (x & y)
 			// temporarily convert integers to their initial float values
 			// this will slow clipping marginally but will make it much easier
 			// to understand the coordinates passed to the callback function
-			PointD tmp = PointD(pt) * invScale_;
-			PointD e1b = PointD(e1bot) * invScale_;
-			PointD e1t = PointD(e1top) * invScale_;
-			PointD e2b = PointD(e2bot) * invScale_;
-			PointD e2t = PointD(e2top) * invScale_;
+			PointS tmp = PointS(pt) * invScale_;
+			PointS e1b = PointS(e1bot) * invScale_;
+			PointS e1t = PointS(e1top) * invScale_;
+			PointS e2b = PointS(e2bot) * invScale_;
+			PointS e2t = PointS(e2top) * invScale_;
 			zCallbackD_(e1b,e1t, e2b, e2t, tmp);
 			pt.z = tmp.z; // only update 'z'
 		};
@@ -563,7 +563,7 @@ namespace Clipper2Lib {
 				// if the user defined float point callback has been assigned
 				// then assign the proxy callback function
 				ClipperBase::zCallback_ =
-					std::bind(&ClipperD::ZCB, this, std::placeholders::_1,
+					std::bind(&ClipperS::ZCB, this, std::placeholders::_1,
 					std::placeholders::_2, std::placeholders::_3,
 					std::placeholders::_4, std::placeholders::_5);
 			else
@@ -572,36 +572,36 @@ namespace Clipper2Lib {
 
 #endif
 
-		void AddSubject(const PathsD& subjects)
+		void AddSubject(const PathsS& subjects)
 		{
-			AddPaths(ScalePaths<int64_t, double>(subjects, scale_, error_code_), PathType::Subject, false);
+			AddPaths(ScalePaths<Integer, Scalar>(subjects, scale_, error_code_), PathType::Subject, false);
 		}
 
-		void AddOpenSubject(const PathsD& open_subjects)
+		void AddOpenSubject(const PathsS& open_subjects)
 		{
-			AddPaths(ScalePaths<int64_t, double>(open_subjects, scale_, error_code_), PathType::Subject, true);
+			AddPaths(ScalePaths<Integer, Scalar>(open_subjects, scale_, error_code_), PathType::Subject, true);
 		}
 
-		void AddClip(const PathsD& clips)
+		void AddClip(const PathsS& clips)
 		{
-			AddPaths(ScalePaths<int64_t, double>(clips, scale_, error_code_), PathType::Clip, false);
+			AddPaths(ScalePaths<Integer, Scalar>(clips, scale_, error_code_), PathType::Clip, false);
 		}
 
-		bool Execute(ClipType clip_type, FillRule fill_rule, PathsD& closed_paths)
+		bool Execute(ClipType clip_type, FillRule fill_rule, PathsS& closed_paths)
 		{
-			PathsD dummy;
+			PathsS dummy;
 			return Execute(clip_type, fill_rule, closed_paths, dummy);
 		}
 
 		bool Execute(ClipType clip_type,
-			FillRule fill_rule, PathsD& closed_paths, PathsD& open_paths)
+			FillRule fill_rule, PathsS& closed_paths, PathsS& open_paths)
 		{
 #ifdef USINGZ
 			CheckCallback();
 #endif
 			if (ExecuteInternal(clip_type, fill_rule, false))
 			{
-				BuildPathsD(closed_paths, &open_paths);
+				BuildPathsS(closed_paths, &open_paths);
 			}
 			CleanUp();
 			return succeeded_;
@@ -609,12 +609,12 @@ namespace Clipper2Lib {
 
 		bool Execute(ClipType clip_type, FillRule fill_rule, PolyTreeD& polytree)
 		{
-			PathsD dummy;
+			PathsS dummy;
 			return Execute(clip_type, fill_rule, polytree, dummy);
 		}
 
 		bool Execute(ClipType clip_type,
-			FillRule fill_rule, PolyTreeD& polytree, PathsD& open_paths)
+			FillRule fill_rule, PolyTreeD& polytree, PathsS& open_paths)
 		{
 #ifdef USINGZ
 			CheckCallback();
@@ -624,7 +624,7 @@ namespace Clipper2Lib {
 				polytree.Clear();
 				polytree.SetScale(invScale_);
 				open_paths.clear();
-				BuildTreeD(polytree, open_paths);
+				BuildTreeS(polytree, open_paths);
 			}
 			CleanUp();
 			return succeeded_;

--- a/CPP/Clipper2Lib/include/clipper2/clipper.export.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.export.h
@@ -20,10 +20,10 @@
 The path structures used extensively in other parts of this library are all
 based on std::vector classes. Since C++ classes can't be accessed by other
 languages, these paths are converted into very simple array data structures 
-(of either int64_t for CPath64 or double for CPathD) that can be parsed by 
+(of either Integer for CPathI or Scalar for CPathS) that can be parsed by 
 just about any programming language.
 
-CPath64 and CPathD:
+CPathI and CPathS:
 These are arrays of consecutive x and y path coordinates preceeded by
 a pair of values containing the path's length (N) and a 0 value.
 __________________________________
@@ -31,12 +31,12 @@ __________________________________
 |N, 0   |x1, y1|x2, y2|...|xN, yN|
 __________________________________
 
-CPaths64 and CPathsD:
-These are also arrays containing any number of consecutive CPath64 or
-CPathD  structures. But preceeding these consecutive paths, there is pair of
+CPathsI and CPathsS:
+These are also arrays containing any number of consecutive CPathI or
+CPathS  structures. But preceeding these consecutive paths, there is pair of
 values that contain the total length of the array structure (A) and the 
-number of CPath64 or CPathD it contains (C). The space these structures will
-occupy in memory = A * sizeof(int64_t) or  A * sizeof(double) respectively. 
+number of CPathI or CPathS it contains (C). The space these structures will
+occupy in memory = A * sizeof(Integer) or  A * sizeof(Scalar) respectively. 
 _______________________________
 |counter|path1|path2|...|pathC|
 |A  , C |                     |
@@ -49,7 +49,7 @@ CPolyPath is just the tree container that doesn't have a path. And because
 of that, its structure will be very slightly different from the remaining
 CPolyPath. This difference will be discussed below.
 
-CPolyPath64 and CPolyPathD:
+CPolyPathI and CPolyPathS:
 These are simple arrays consisting of a series of path coordinates followed
 by any number of child (ie nested) CPolyPath. Preceeding these are two values
 indicating the length of the path (N) and the number of child CPolyPath (C).
@@ -64,15 +64,15 @@ Since this first CPolyPath has no path, instead of a path length, its very
 first value will contain the total length of the CPolytree array (not its
 total bytes length).
 
-Again, all theses exported structures (CPaths64, CPathsD, CPolyTree64 & 
-CPolyTreeD) are arrays of either type int64_t or double, and the first 
+Again, all theses exported structures (CPathsI, CPathsS, CPolyTreeI & 
+CPolyTreeS) are arrays of either type Integer or Scalar, and the first 
 value in these arrays will always be the length of that array.
 
 These array structures are allocated in heap memory which will eventually
 need to be released. However, since applications dynamically linking to 
 these functions may use different memory managers, the only safe way to 
-free up this memory is to use the exported DisposeArray64 and 
-DisposeArrayD functions (see below).
+free up this memory is to use the exported DisposeArrayI and 
+DisposeArrayS functions (see below).
 */
 
 
@@ -89,15 +89,15 @@ DisposeArrayD functions (see below).
 
 namespace Clipper2Lib {
 
-typedef int64_t* CPath64;
-typedef int64_t* CPaths64;
-typedef double*  CPathD;
-typedef double*  CPathsD;
+typedef Integer* CPathI;
+typedef Integer* CPathsI;
+typedef Scalar*  CPathS;
+typedef Scalar*  CPathsS;
 
-typedef int64_t* CPolyPath64;
-typedef int64_t* CPolyTree64;
-typedef double* CPolyPathD;
-typedef double* CPolyTreeD;
+typedef Integer* CPolyPathI;
+typedef Integer* CPolyTreeI;
+typedef Scalar* CPolyPathS;
+typedef Scalar* CPolyTreeS;
 
 template <typename T>
 struct CRect {
@@ -107,8 +107,8 @@ struct CRect {
   T bottom;
 };
 
-typedef CRect<int64_t> CRect64;
-typedef CRect<double> CRectD;
+typedef CRect<Integer> CRectI;
+typedef CRect<Scalar> CRectS;
 
 template <typename T>
 inline bool CRectIsEmpty(const CRect<T>& rect)
@@ -140,58 +140,58 @@ inline Rect<T> CRectToRect(const CRect<T>& rect)
 
 EXTERN_DLL_EXPORT const char* Version();
 
-EXTERN_DLL_EXPORT void DisposeArray64(int64_t*& p)
+EXTERN_DLL_EXPORT void DisposeArrayI(Integer*& p)
 {
   delete[] p;
 }
 
-EXTERN_DLL_EXPORT void DisposeArrayD(double*& p)
+EXTERN_DLL_EXPORT void DisposeArrayS(Scalar*& p)
 {
   delete[] p;
 }
 
-EXTERN_DLL_EXPORT int BooleanOp64(uint8_t cliptype,
-  uint8_t fillrule, const CPaths64 subjects,
-  const CPaths64 subjects_open, const CPaths64 clips,
-  CPaths64& solution, CPaths64& solution_open,
+EXTERN_DLL_EXPORT int BooleanOpI(uint8_t cliptype,
+  uint8_t fillrule, const CPathsI subjects,
+  const CPathsI subjects_open, const CPathsI clips,
+  CPathsI& solution, CPathsI& solution_open,
   bool preserve_collinear = true, bool reverse_solution = false);
 
-EXTERN_DLL_EXPORT int BooleanOp_PolyTree64(uint8_t cliptype,
-  uint8_t fillrule, const CPaths64 subjects,
-  const CPaths64 subjects_open, const CPaths64 clips,
-  CPolyTree64& sol_tree, CPaths64& solution_open,
+EXTERN_DLL_EXPORT int BooleanOp_PolyTreeI(uint8_t cliptype,
+  uint8_t fillrule, const CPathsI subjects,
+  const CPathsI subjects_open, const CPathsI clips,
+  CPolyTreeI& sol_tree, CPathsI& solution_open,
   bool preserve_collinear = true, bool reverse_solution = false);
 
-EXTERN_DLL_EXPORT int BooleanOpD(uint8_t cliptype,
-  uint8_t fillrule, const CPathsD subjects,
-  const CPathsD subjects_open, const CPathsD clips,
-  CPathsD& solution, CPathsD& solution_open, int precision = 2,
+EXTERN_DLL_EXPORT int BooleanOpS(uint8_t cliptype,
+  uint8_t fillrule, const CPathsS subjects,
+  const CPathsS subjects_open, const CPathsS clips,
+  CPathsS& solution, CPathsS& solution_open, int precision = 2,
   bool preserve_collinear = true, bool reverse_solution = false);
 
-EXTERN_DLL_EXPORT int BooleanOp_PolyTreeD(uint8_t cliptype,
-  uint8_t fillrule, const CPathsD subjects,
-  const CPathsD subjects_open, const CPathsD clips,
-  CPolyTreeD& solution, CPathsD& solution_open, int precision = 2,
+EXTERN_DLL_EXPORT int BooleanOp_PolyTreeS(uint8_t cliptype,
+  uint8_t fillrule, const CPathsS subjects,
+  const CPathsS subjects_open, const CPathsS clips,
+  CPolyTreeS& solution, CPathsS& solution_open, int precision = 2,
   bool preserve_collinear = true, bool reverse_solution = false);
 
-EXTERN_DLL_EXPORT CPaths64 InflatePaths64(const CPaths64 paths,
-  double delta, uint8_t jointype, uint8_t endtype,
-  double miter_limit = 2.0, double arc_tolerance = 0.0,
+EXTERN_DLL_EXPORT CPathsI InflatePathsI(const CPathsI paths,
+  Scalar delta, uint8_t jointype, uint8_t endtype,
+  Scalar miter_limit = 2.0, Scalar arc_tolerance = 0.0,
   bool reverse_solution = false);
-EXTERN_DLL_EXPORT CPathsD InflatePathsD(const CPathsD paths,
-  double delta, uint8_t jointype, uint8_t endtype,
-  int precision = 2, double miter_limit = 2.0,
-  double arc_tolerance = 0.0, bool reverse_solution = false);
+EXTERN_DLL_EXPORT CPathsS InflatePathsS(const CPathsS paths,
+  Scalar delta, uint8_t jointype, uint8_t endtype,
+  int precision = 2, Scalar miter_limit = 2.0,
+  Scalar arc_tolerance = 0.0, bool reverse_solution = false);
 
 // RectClip & RectClipLines:
-EXTERN_DLL_EXPORT CPaths64 RectClip64(const CRect64& rect,
-  const CPaths64 paths);
-EXTERN_DLL_EXPORT CPathsD RectClipD(const CRectD& rect,
-  const CPathsD paths, int precision = 2);
-EXTERN_DLL_EXPORT CPaths64 RectClipLines64(const CRect64& rect,
-  const CPaths64 paths);
-EXTERN_DLL_EXPORT CPathsD RectClipLinesD(const CRectD& rect,
-  const CPathsD paths, int precision = 2);
+EXTERN_DLL_EXPORT CPathsI RectClipI(const CRectI& rect,
+  const CPathsI paths);
+EXTERN_DLL_EXPORT CPathsS RectClipS(const CRectS& rect,
+  const CPathsS paths, int precision = 2);
+EXTERN_DLL_EXPORT CPathsI RectClipLinesI(const CRectI& rect,
+  const CPathsI paths);
+EXTERN_DLL_EXPORT CPathsS RectClipLinesS(const CRectS& rect,
+  const CPathsS paths, int precision = 2);
 
 //////////////////////////////////////////////////////
 // INTERNAL FUNCTIONS
@@ -211,21 +211,21 @@ static void GetPathCountAndCPathsArrayLen(const Paths<T>& paths,
     }
 }
 
-static size_t GetPolyPath64ArrayLen(const PolyPath64& pp)
+static size_t GetPolyPathIArrayLen(const PolyPathI& pp)
 {
   size_t result = 2; // poly_length + child_count
   result += pp.Polygon().size() * 2;
   //plus nested children :)
   for (size_t i = 0; i < pp.Count(); ++i)
-    result += GetPolyPath64ArrayLen(*pp[i]);
+    result += GetPolyPathIArrayLen(*pp[i]);
   return result;
 }
 
-static void GetPolytreeCountAndCStorageSize(const PolyTree64& tree,
+static void GetPolytreeCountAndCStorageSize(const PolyTreeI& tree,
   size_t& cnt, size_t& array_len)
 {
   cnt = tree.Count(); // nb: top level count only
-  array_len = GetPolyPath64ArrayLen(tree);
+  array_len = GetPolyPathIArrayLen(tree);
 }
 
 template <typename T>
@@ -251,20 +251,20 @@ static T* CreateCPaths(const Paths<T>& paths)
 }
 
 
-CPathsD CreateCPathsDFromPaths64(const Paths64& paths, double scale)
+CPathsS CreateCPathsDFromPathsI(const PathsI& paths, Scalar scale)
 {
   if (!paths.size()) return nullptr;
   size_t cnt, array_len;
   GetPathCountAndCPathsArrayLen(paths, cnt, array_len);
-  CPathsD result = new double[array_len], v = result;
-  *v++ = (double)array_len;
-  *v++ = (double)cnt;
-  for (const Path64& path : paths)
+  CPathsS result = new Scalar[array_len], v = result;
+  *v++ = (Scalar)array_len;
+  *v++ = (Scalar)cnt;
+  for (const PathI& path : paths)
   {
     if (!path.size()) continue;
-    *v = (double)path.size();
+    *v = (Scalar)path.size();
     ++v; *v++ = 0;
-    for (const Point64& pt : path)
+    for (const PointI& pt : path)
     {
       *v++ = pt.x * scale;
       *v++ = pt.y * scale;
@@ -315,11 +315,11 @@ static Paths<T> ConvertCPaths(T* paths)
 }
 
 
-static Paths64 ConvertCPathsDToPaths64(const CPathsD paths, double scale)
+static PathsI ConvertCPathsDToPathsI(const CPathsS paths, Scalar scale)
 {
-  Paths64 result;
+  PathsI result;
   if (!paths) return result;
-  double* v = paths;
+  Scalar* v = paths;
   ++v; // skip the first value (0)
   size_t cnt = static_cast<size_t>(*v++);
   result.reserve(cnt);
@@ -327,13 +327,13 @@ static Paths64 ConvertCPathsDToPaths64(const CPathsD paths, double scale)
   {
     size_t cnt2 = static_cast<size_t>(*v);
     v += 2;
-    Path64 path;
+    PathI path;
     path.reserve(cnt2);
     for (size_t j = 0; j < cnt2; ++j)
     {
-      double x = *v++ * scale;
-      double y = *v++ * scale;
-      path.push_back(Point64(x, y));
+      Scalar x = *v++ * scale;
+      Scalar y = *v++ * scale;
+      path.push_back(PointI(x, y));
     }
     result.push_back(path);
   }
@@ -341,11 +341,11 @@ static Paths64 ConvertCPathsDToPaths64(const CPathsD paths, double scale)
 }
 
 template <typename T>
-static void CreateCPolyPath(const PolyPath64* pp, T*& v, T scale)
+static void CreateCPolyPath(const PolyPathI* pp, T*& v, T scale)
 {
   *v++ = static_cast<T>(pp->Polygon().size());
   *v++ = static_cast<T>(pp->Count());
-  for (const Point64& pt : pp->Polygon())
+  for (const PointI& pt : pp->Polygon())
   {
     *v++ = static_cast<T>(pt.x * scale);
     *v++ = static_cast<T>(pt.y * scale);
@@ -355,7 +355,7 @@ static void CreateCPolyPath(const PolyPath64* pp, T*& v, T scale)
 }
 
 template <typename T>
-static T* CreateCPolyTree(const PolyTree64& tree, T scale)
+static T* CreateCPolyTree(const PolyTreeI& tree, T scale)
 {
   if (scale == 0) scale = 1;
   size_t cnt, array_len;
@@ -381,21 +381,21 @@ EXTERN_DLL_EXPORT const char* Version()
   return CLIPPER2_VERSION;
 }
 
-EXTERN_DLL_EXPORT int BooleanOp64(uint8_t cliptype,
-  uint8_t fillrule, const CPaths64 subjects,
-  const CPaths64 subjects_open, const CPaths64 clips,
-  CPaths64& solution, CPaths64& solution_open,
+EXTERN_DLL_EXPORT int BooleanOpI(uint8_t cliptype,
+  uint8_t fillrule, const CPathsI subjects,
+  const CPathsI subjects_open, const CPathsI clips,
+  CPathsI& solution, CPathsI& solution_open,
   bool preserve_collinear, bool reverse_solution)
 {
   if (cliptype > static_cast<uint8_t>(ClipType::Xor)) return -4;
   if (fillrule > static_cast<uint8_t>(FillRule::Negative)) return -3;
 
-  Paths64 sub, sub_open, clp, sol, sol_open;
+  PathsI sub, sub_open, clp, sol, sol_open;
   sub       = ConvertCPaths(subjects);
   sub_open  = ConvertCPaths(subjects_open);
   clp       = ConvertCPaths(clips);
 
-  Clipper64 clipper;
+  ClipperI clipper;
   clipper.PreserveCollinear(preserve_collinear);
   clipper.ReverseSolution(reverse_solution);
   if (sub.size() > 0) clipper.AddSubject(sub);
@@ -408,21 +408,21 @@ EXTERN_DLL_EXPORT int BooleanOp64(uint8_t cliptype,
   return 0; //success !!
 }
 
-EXTERN_DLL_EXPORT int BooleanOp_PolyTree64(uint8_t cliptype,
-  uint8_t fillrule, const CPaths64 subjects,
-  const CPaths64 subjects_open, const CPaths64 clips,
-  CPolyTree64& sol_tree, CPaths64& solution_open,
+EXTERN_DLL_EXPORT int BooleanOp_PolyTreeI(uint8_t cliptype,
+  uint8_t fillrule, const CPathsI subjects,
+  const CPathsI subjects_open, const CPathsI clips,
+  CPolyTreeI& sol_tree, CPathsI& solution_open,
   bool preserve_collinear, bool reverse_solution)
 {
   if (cliptype > static_cast<uint8_t>(ClipType::Xor)) return -4;
   if (fillrule > static_cast<uint8_t>(FillRule::Negative)) return -3;
-  Paths64 sub, sub_open, clp, sol_open;
+  PathsI sub, sub_open, clp, sol_open;
   sub = ConvertCPaths(subjects);
   sub_open = ConvertCPaths(subjects_open);
   clp = ConvertCPaths(clips);
 
-  PolyTree64 tree;
-  Clipper64 clipper;
+  PolyTreeI tree;
+  ClipperI clipper;
   clipper.PreserveCollinear(preserve_collinear);
   clipper.ReverseSolution(reverse_solution);
   if (sub.size() > 0) clipper.AddSubject(sub);
@@ -431,28 +431,28 @@ EXTERN_DLL_EXPORT int BooleanOp_PolyTree64(uint8_t cliptype,
   if (!clipper.Execute(ClipType(cliptype), FillRule(fillrule), tree, sol_open))
     return -1; // clipping bug - should never happen :)
 
-  sol_tree = CreateCPolyTree(tree, (int64_t)1);
+  sol_tree = CreateCPolyTree(tree, (Integer)1);
   solution_open = CreateCPaths(sol_open);
   return 0; //success !!
 }
 
-EXTERN_DLL_EXPORT int BooleanOpD(uint8_t cliptype,
-  uint8_t fillrule, const CPathsD subjects,
-  const CPathsD subjects_open, const CPathsD clips,
-  CPathsD& solution, CPathsD& solution_open, int precision,
+EXTERN_DLL_EXPORT int BooleanOpS(uint8_t cliptype,
+  uint8_t fillrule, const CPathsS subjects,
+  const CPathsS subjects_open, const CPathsS clips,
+  CPathsS& solution, CPathsS& solution_open, int precision,
   bool preserve_collinear, bool reverse_solution)
 {
   if (precision < -8 || precision > 8) return -5;
   if (cliptype > static_cast<uint8_t>(ClipType::Xor)) return -4;
   if (fillrule > static_cast<uint8_t>(FillRule::Negative)) return -3;
-  const double scale = std::pow(10, precision);
+  const Scalar scale = std::pow(10, precision);
 
-  Paths64 sub, sub_open, clp, sol, sol_open;
-  sub       = ConvertCPathsDToPaths64(subjects, scale);
-  sub_open  = ConvertCPathsDToPaths64(subjects_open, scale);
-  clp       = ConvertCPathsDToPaths64(clips, scale);
+  PathsI sub, sub_open, clp, sol, sol_open;
+  sub       = ConvertCPathsDToPathsI(subjects, scale);
+  sub_open  = ConvertCPathsDToPathsI(subjects_open, scale);
+  clp       = ConvertCPathsDToPathsI(clips, scale);
 
-  Clipper64 clipper;
+  ClipperI clipper;
   clipper.PreserveCollinear(preserve_collinear);
   clipper.ReverseSolution(reverse_solution);
   if (sub.size() > 0) clipper.AddSubject(sub);
@@ -460,31 +460,31 @@ EXTERN_DLL_EXPORT int BooleanOpD(uint8_t cliptype,
   if (clp.size() > 0) clipper.AddClip(clp);
   if (!clipper.Execute(ClipType(cliptype),
     FillRule(fillrule), sol, sol_open)) return -1;
-  solution = CreateCPathsDFromPaths64(sol, 1 / scale);
-  solution_open = CreateCPathsDFromPaths64(sol_open, 1 / scale);
+  solution = CreateCPathsDFromPathsI(sol, 1 / scale);
+  solution_open = CreateCPathsDFromPathsI(sol_open, 1 / scale);
   return 0;
 }
 
-EXTERN_DLL_EXPORT int BooleanOp_PolyTreeD(uint8_t cliptype,
-  uint8_t fillrule, const CPathsD subjects,
-  const CPathsD subjects_open, const CPathsD clips,
-  CPolyTreeD& solution, CPathsD& solution_open, int precision,
+EXTERN_DLL_EXPORT int BooleanOp_PolyTreeS(uint8_t cliptype,
+  uint8_t fillrule, const CPathsS subjects,
+  const CPathsS subjects_open, const CPathsS clips,
+  CPolyTreeS& solution, CPathsS& solution_open, int precision,
   bool preserve_collinear, bool reverse_solution)
 {
   if (precision < -8 || precision > 8) return -5;
   if (cliptype > static_cast<uint8_t>(ClipType::Xor)) return -4;
   if (fillrule > static_cast<uint8_t>(FillRule::Negative)) return -3;
 
-  double scale = std::pow(10, precision);
+  Scalar scale = std::pow(10, precision);
 
   int err = 0;
-  Paths64 sub, sub_open, clp, sol_open;
-  sub = ConvertCPathsDToPaths64(subjects, scale);
-  sub_open = ConvertCPathsDToPaths64(subjects_open, scale);
-  clp = ConvertCPathsDToPaths64(clips, scale);
+  PathsI sub, sub_open, clp, sol_open;
+  sub = ConvertCPathsDToPathsI(subjects, scale);
+  sub_open = ConvertCPathsDToPathsI(subjects_open, scale);
+  clp = ConvertCPathsDToPathsI(clips, scale);
 
-  PolyTree64 tree;
-  Clipper64 clipper;
+  PolyTreeI tree;
+  ClipperI clipper;
   clipper.PreserveCollinear(preserve_collinear);
   clipper.ReverseSolution(reverse_solution);
   if (sub.size() > 0) clipper.AddSubject(sub);
@@ -494,104 +494,104 @@ EXTERN_DLL_EXPORT int BooleanOp_PolyTreeD(uint8_t cliptype,
     return -1; // clipping bug - should never happen :)
 
   solution = CreateCPolyTree(tree, 1/scale);
-  solution_open = CreateCPathsDFromPaths64(sol_open, 1 / scale);
+  solution_open = CreateCPathsDFromPathsI(sol_open, 1 / scale);
   return 0; //success !!
 }
 
-EXTERN_DLL_EXPORT CPaths64 InflatePaths64(const CPaths64 paths,
-  double delta, uint8_t jointype, uint8_t endtype, double miter_limit,
-  double arc_tolerance, bool reverse_solution)
+EXTERN_DLL_EXPORT CPathsI InflatePathsI(const CPathsI paths,
+  Scalar delta, uint8_t jointype, uint8_t endtype, Scalar miter_limit,
+  Scalar arc_tolerance, bool reverse_solution)
 {
-  Paths64 pp;
+  PathsI pp;
   pp = ConvertCPaths(paths);
   ClipperOffset clip_offset( miter_limit,
     arc_tolerance, reverse_solution);
   clip_offset.AddPaths(pp, JoinType(jointype), EndType(endtype));
-  Paths64 result;
+  PathsI result;
   clip_offset.Execute(delta, result);
   return CreateCPaths(result);
 }
 
-EXTERN_DLL_EXPORT CPathsD InflatePathsD(const CPathsD paths,
-  double delta, uint8_t jointype, uint8_t endtype,
-  int precision, double miter_limit,
-  double arc_tolerance, bool reverse_solution)
+EXTERN_DLL_EXPORT CPathsS InflatePathsS(const CPathsS paths,
+  Scalar delta, uint8_t jointype, uint8_t endtype,
+  int precision, Scalar miter_limit,
+  Scalar arc_tolerance, bool reverse_solution)
 {
   if (precision < -8 || precision > 8 || !paths) return nullptr;
 
-  const double scale = std::pow(10, precision);
+  const Scalar scale = std::pow(10, precision);
   ClipperOffset clip_offset(miter_limit, arc_tolerance, reverse_solution);
-  Paths64 pp = ConvertCPathsDToPaths64(paths, scale);
+  PathsI pp = ConvertCPathsDToPathsI(paths, scale);
   clip_offset.AddPaths(pp, JoinType(jointype), EndType(endtype));
-  Paths64 result;
+  PathsI result;
   clip_offset.Execute(delta * scale, result);
 
-  return CreateCPathsDFromPaths64(result, 1 / scale);
+  return CreateCPathsDFromPathsI(result, 1 / scale);
 }
 
-EXTERN_DLL_EXPORT CPaths64 RectClip64(const CRect64& rect, const CPaths64 paths)
+EXTERN_DLL_EXPORT CPathsI RectClipI(const CRectI& rect, const CPathsI paths)
 {
   if (CRectIsEmpty(rect) || !paths) return nullptr;
-  Rect64 r64 = CRectToRect(rect);
-  class RectClip64 rc(r64);
-  Paths64 pp = ConvertCPaths(paths);
-  Paths64 result = rc.Execute(pp);
+  RectI r64 = CRectToRect(rect);
+  class RectClipI rc(r64);
+  PathsI pp = ConvertCPaths(paths);
+  PathsI result = rc.Execute(pp);
   return CreateCPaths(result);
 }
 
-EXTERN_DLL_EXPORT CPathsD RectClipD(const CRectD& rect, const CPathsD paths, int precision)
+EXTERN_DLL_EXPORT CPathsS RectClipS(const CRectS& rect, const CPathsS paths, int precision)
 {
   if (CRectIsEmpty(rect) || !paths) return nullptr;
   if (precision < -8 || precision > 8) return nullptr;
-  const double scale = std::pow(10, precision);
+  const Scalar scale = std::pow(10, precision);
 
-  RectD r = CRectToRect(rect);
-  Rect64 rec = ScaleRect<int64_t, double>(r, scale);
-  Paths64 pp = ConvertCPathsDToPaths64(paths, scale);
-  class RectClip64 rc(rec);
-  Paths64 result = rc.Execute(pp);
+  RectS r = CRectToRect(rect);
+  RectI rec = ScaleRect<Integer, Scalar>(r, scale);
+  PathsI pp = ConvertCPathsDToPathsI(paths, scale);
+  class RectClipI rc(rec);
+  PathsI result = rc.Execute(pp);
 
-  return CreateCPathsDFromPaths64(result, 1 / scale);
+  return CreateCPathsDFromPathsI(result, 1 / scale);
 }
 
-EXTERN_DLL_EXPORT CPaths64 RectClipLines64(const CRect64& rect,
-  const CPaths64 paths)
+EXTERN_DLL_EXPORT CPathsI RectClipLinesI(const CRectI& rect,
+  const CPathsI paths)
 {
   if (CRectIsEmpty(rect) || !paths) return nullptr;
-  Rect64 r = CRectToRect(rect);
-  class RectClipLines64 rcl (r);
-  Paths64 pp = ConvertCPaths(paths);
-  Paths64 result = rcl.Execute(pp);
+  RectI r = CRectToRect(rect);
+  class RectClipLinesI rcl (r);
+  PathsI pp = ConvertCPaths(paths);
+  PathsI result = rcl.Execute(pp);
   return CreateCPaths(result);
 }
 
-EXTERN_DLL_EXPORT CPathsD RectClipLinesD(const CRectD& rect,
-  const CPathsD paths, int precision)
+EXTERN_DLL_EXPORT CPathsS RectClipLinesS(const CRectS& rect,
+  const CPathsS paths, int precision)
 {
   if (CRectIsEmpty(rect) || !paths) return nullptr;
   if (precision < -8 || precision > 8) return nullptr;
 
-  const double scale = std::pow(10, precision);
-  Rect64 r = ScaleRect<int64_t, double>(CRectToRect(rect), scale);
-  class RectClipLines64 rcl(r);
-  Paths64 pp = ConvertCPathsDToPaths64(paths, scale);
-  Paths64 result = rcl.Execute(pp);
-  return CreateCPathsDFromPaths64(result, 1 / scale);
+  const Scalar scale = std::pow(10, precision);
+  RectI r = ScaleRect<Integer, Scalar>(CRectToRect(rect), scale);
+  class RectClipLinesI rcl(r);
+  PathsI pp = ConvertCPathsDToPathsI(paths, scale);
+  PathsI result = rcl.Execute(pp);
+  return CreateCPathsDFromPathsI(result, 1 / scale);
 }
 
-EXTERN_DLL_EXPORT CPaths64 MinkowskiSum64(const CPath64& cpattern, const CPath64& cpath, bool is_closed)
+EXTERN_DLL_EXPORT CPathsI MinkowskiSumI(const CPathI& cpattern, const CPathI& cpath, bool is_closed)
 {
-  Path64 path = ConvertCPath(cpath);
-  Path64 pattern = ConvertCPath(cpattern);
-  Paths64 solution = MinkowskiSum(pattern, path, is_closed);
+  PathI path = ConvertCPath(cpath);
+  PathI pattern = ConvertCPath(cpattern);
+  PathsI solution = MinkowskiSum(pattern, path, is_closed);
   return CreateCPaths(solution);
 }
 
-EXTERN_DLL_EXPORT CPaths64 MinkowskiDiff64(const CPath64& cpattern, const CPath64& cpath, bool is_closed)
+EXTERN_DLL_EXPORT CPathsI MinkowskiDiff64(const CPathI& cpattern, const CPathI& cpath, bool is_closed)
 {
-  Path64 path = ConvertCPath(cpath);
-  Path64 pattern = ConvertCPath(cpattern);
-  Paths64 solution = MinkowskiDiff(pattern, path, is_closed);
+  PathI path = ConvertCPath(cpath);
+  PathI pattern = ConvertCPath(cpattern);
+  PathsI solution = MinkowskiDiff(pattern, path, is_closed);
   return CreateCPaths(solution);
 }
 

--- a/CPP/Clipper2Lib/include/clipper2/clipper.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.h
@@ -22,11 +22,11 @@
 
 namespace Clipper2Lib {
 
-  inline Paths64 BooleanOp(ClipType cliptype, FillRule fillrule,
-    const Paths64& subjects, const Paths64& clips)
+  inline PathsI BooleanOp(ClipType cliptype, FillRule fillrule,
+    const PathsI& subjects, const PathsI& clips)
   {
-    Paths64 result;
-    Clipper64 clipper;
+    PathsI result;
+    ClipperI clipper;
     clipper.AddSubject(subjects);
     clipper.AddClip(clips);
     clipper.Execute(cliptype, fillrule, result);
@@ -34,23 +34,23 @@ namespace Clipper2Lib {
   }
 
   inline void BooleanOp(ClipType cliptype, FillRule fillrule,
-    const Paths64& subjects, const Paths64& clips, PolyTree64& solution)
+    const PathsI& subjects, const PathsI& clips, PolyTreeI& solution)
   {
-    Paths64 sol_open;
-    Clipper64 clipper;
+    PathsI sol_open;
+    ClipperI clipper;
     clipper.AddSubject(subjects);
     clipper.AddClip(clips);
     clipper.Execute(cliptype, fillrule, solution, sol_open);
   }
 
-  inline PathsD BooleanOp(ClipType cliptype, FillRule fillrule,
-    const PathsD& subjects, const PathsD& clips, int precision = 2)
+  inline PathsS BooleanOp(ClipType cliptype, FillRule fillrule,
+    const PathsS& subjects, const PathsS& clips, int precision = 2)
   {
     int error_code = 0;
     CheckPrecisionRange(precision, error_code);
-    PathsD result;
+    PathsS result;
     if (error_code) return result;
-    ClipperD clipper(precision);
+    ClipperS clipper(precision);
     clipper.AddSubject(subjects);
     clipper.AddClip(clips);
     clipper.Execute(cliptype, fillrule, result);
@@ -58,107 +58,107 @@ namespace Clipper2Lib {
   }
 
   inline void BooleanOp(ClipType cliptype, FillRule fillrule,
-    const PathsD& subjects, const PathsD& clips,
+    const PathsS& subjects, const PathsS& clips,
     PolyTreeD& polytree, int precision = 2)
   {
     polytree.Clear();
     int error_code = 0;
     CheckPrecisionRange(precision, error_code);
     if (error_code) return;
-    ClipperD clipper(precision);
+    ClipperS clipper(precision);
     clipper.AddSubject(subjects);
     clipper.AddClip(clips);
     clipper.Execute(cliptype, fillrule, polytree);
   }
 
-  inline Paths64 Intersect(const Paths64& subjects, const Paths64& clips, FillRule fillrule)
+  inline PathsI Intersect(const PathsI& subjects, const PathsI& clips, FillRule fillrule)
   {
     return BooleanOp(ClipType::Intersection, fillrule, subjects, clips);
   }
 
-  inline PathsD Intersect(const PathsD& subjects, const PathsD& clips, FillRule fillrule, int decimal_prec = 2)
+  inline PathsS Intersect(const PathsS& subjects, const PathsS& clips, FillRule fillrule, int decimal_prec = 2)
   {
     return BooleanOp(ClipType::Intersection, fillrule, subjects, clips, decimal_prec);
   }
 
-  inline Paths64 Union(const Paths64& subjects, const Paths64& clips, FillRule fillrule)
+  inline PathsI Union(const PathsI& subjects, const PathsI& clips, FillRule fillrule)
   {
     return BooleanOp(ClipType::Union, fillrule, subjects, clips);
   }
 
-  inline PathsD Union(const PathsD& subjects, const PathsD& clips, FillRule fillrule, int decimal_prec = 2)
+  inline PathsS Union(const PathsS& subjects, const PathsS& clips, FillRule fillrule, int decimal_prec = 2)
   {
     return BooleanOp(ClipType::Union, fillrule, subjects, clips, decimal_prec);
   }
 
-  inline Paths64 Union(const Paths64& subjects, FillRule fillrule)
+  inline PathsI Union(const PathsI& subjects, FillRule fillrule)
   {
-    Paths64 result;
-    Clipper64 clipper;
+    PathsI result;
+    ClipperI clipper;
     clipper.AddSubject(subjects);
     clipper.Execute(ClipType::Union, fillrule, result);
     return result;
   }
 
-  inline PathsD Union(const PathsD& subjects, FillRule fillrule, int precision = 2)
+  inline PathsS Union(const PathsS& subjects, FillRule fillrule, int precision = 2)
   {
-    PathsD result;
+    PathsS result;
     int error_code = 0;
     CheckPrecisionRange(precision, error_code);
     if (error_code) return result;
-    ClipperD clipper(precision);
+    ClipperS clipper(precision);
     clipper.AddSubject(subjects);
     clipper.Execute(ClipType::Union, fillrule, result);
     return result;
   }
 
-  inline Paths64 Difference(const Paths64& subjects, const Paths64& clips, FillRule fillrule)
+  inline PathsI Difference(const PathsI& subjects, const PathsI& clips, FillRule fillrule)
   {
     return BooleanOp(ClipType::Difference, fillrule, subjects, clips);
   }
 
-  inline PathsD Difference(const PathsD& subjects, const PathsD& clips, FillRule fillrule, int decimal_prec = 2)
+  inline PathsS Difference(const PathsS& subjects, const PathsS& clips, FillRule fillrule, int decimal_prec = 2)
   {
     return BooleanOp(ClipType::Difference, fillrule, subjects, clips, decimal_prec);
   }
 
-  inline Paths64 Xor(const Paths64& subjects, const Paths64& clips, FillRule fillrule)
+  inline PathsI Xor(const PathsI& subjects, const PathsI& clips, FillRule fillrule)
   {
     return BooleanOp(ClipType::Xor, fillrule, subjects, clips);
   }
 
-  inline PathsD Xor(const PathsD& subjects, const PathsD& clips, FillRule fillrule, int decimal_prec = 2)
+  inline PathsS Xor(const PathsS& subjects, const PathsS& clips, FillRule fillrule, int decimal_prec = 2)
   {
     return BooleanOp(ClipType::Xor, fillrule, subjects, clips, decimal_prec);
   }
 
-  inline Paths64 InflatePaths(const Paths64& paths, double delta,
-    JoinType jt, EndType et, double miter_limit = 2.0,
-    double arc_tolerance = 0.0)
+  inline PathsI InflatePaths(const PathsI& paths, Scalar delta,
+    JoinType jt, EndType et, Scalar miter_limit = 2.0,
+    Scalar arc_tolerance = 0.0)
   {
     if (!delta) return paths;
     ClipperOffset clip_offset(miter_limit, arc_tolerance);
     clip_offset.AddPaths(paths, jt, et);
-    Paths64 solution;
+    PathsI solution;
     clip_offset.Execute(delta, solution);
     return solution;
   }
 
-  inline PathsD InflatePaths(const PathsD& paths, double delta,
-    JoinType jt, EndType et, double miter_limit = 2.0,
-    int precision = 2, double arc_tolerance = 0.0)
+  inline PathsS InflatePaths(const PathsS& paths, Scalar delta,
+    JoinType jt, EndType et, Scalar miter_limit = 2.0,
+    int precision = 2, Scalar arc_tolerance = 0.0)
   {
     int error_code = 0;
     CheckPrecisionRange(precision, error_code);
     if (!delta) return paths;
-    if (error_code) return PathsD();
-    const double scale = std::pow(10, precision);
+    if (error_code) return PathsS();
+    const Scalar scale = (Scalar)std::pow(10, precision);
     ClipperOffset clip_offset(miter_limit, arc_tolerance);
-    clip_offset.AddPaths(ScalePaths<int64_t,double>(paths, scale, error_code), jt, et);
-    if (error_code) return PathsD();
-    Paths64 solution;
+    clip_offset.AddPaths(ScalePaths<Integer,Scalar>(paths, scale, error_code), jt, et);
+    if (error_code) return PathsS();
+    PathsI solution;
     clip_offset.Execute(delta * scale, solution);
-    return ScalePaths<double, int64_t>(solution, 1 / scale, error_code);
+    return ScalePaths<Scalar, Integer>(solution, 1 / scale, error_code);
   }
 
   template <typename T>
@@ -171,14 +171,14 @@ namespace Clipper2Lib {
     return result;
   }
 
-  inline Path64 TranslatePath(const Path64& path, int64_t dx, int64_t dy)
+  inline PathI TranslatePath(const PathI& path, Integer dx, Integer dy)
   {
-    return TranslatePath<int64_t>(path, dx, dy);
+    return TranslatePath<Integer>(path, dx, dy);
   }
 
-  inline PathD TranslatePath(const PathD& path, double dx, double dy)
+  inline PathS TranslatePath(const PathS& path, Scalar dx, Scalar dy)
   {
-    return TranslatePath<double>(path, dx, dy);
+    return TranslatePath<Scalar>(path, dx, dy);
   }
 
   template <typename T>
@@ -191,100 +191,100 @@ namespace Clipper2Lib {
     return result;
   }
 
-  inline Paths64 TranslatePaths(const Paths64& paths, int64_t dx, int64_t dy)
+  inline PathsI TranslatePaths(const PathsI& paths, Integer dx, Integer dy)
   {
-    return TranslatePaths<int64_t>(paths, dx, dy);
+    return TranslatePaths<Integer>(paths, dx, dy);
   }
 
-  inline PathsD TranslatePaths(const PathsD& paths, double dx, double dy)
+  inline PathsS TranslatePaths(const PathsS& paths, Scalar dx, Scalar dy)
   {
-    return TranslatePaths<double>(paths, dx, dy);
+    return TranslatePaths<Scalar>(paths, dx, dy);
   }
 
-  inline Paths64 RectClip(const Rect64& rect, const Paths64& paths)
+  inline PathsI RectClip(const RectI& rect, const PathsI& paths)
   {
-    if (rect.IsEmpty() || paths.empty()) return Paths64();
-    RectClip64 rc(rect);
+    if (rect.IsEmpty() || paths.empty()) return PathsI();
+    RectClipI rc(rect);
     return rc.Execute(paths);
   }
 
-  inline Paths64 RectClip(const Rect64& rect, const Path64& path)
+  inline PathsI RectClip(const RectI& rect, const PathI& path)
   {
-    if (rect.IsEmpty() || path.empty()) return Paths64();
-    RectClip64 rc(rect);
-    return rc.Execute(Paths64{ path });
+    if (rect.IsEmpty() || path.empty()) return PathsI();
+    RectClipI rc(rect);
+    return rc.Execute(PathsI{ path });
   }
 
-  inline PathsD RectClip(const RectD& rect, const PathsD& paths, int precision = 2)
+  inline PathsS RectClip(const RectS& rect, const PathsS& paths, int precision = 2)
   {
-    if (rect.IsEmpty() || paths.empty()) return PathsD();
+    if (rect.IsEmpty() || paths.empty()) return PathsS();
     int error_code = 0;
     CheckPrecisionRange(precision, error_code);
-    if (error_code) return PathsD();
-    const double scale = std::pow(10, precision);
-    Rect64 r = ScaleRect<int64_t, double>(rect, scale);
-    RectClip64 rc(r);
-    Paths64 pp = ScalePaths<int64_t, double>(paths, scale, error_code);
-    if (error_code) return PathsD(); // ie: error_code result is lost
-    return ScalePaths<double, int64_t>(
+    if (error_code) return PathsS();
+    const Scalar scale = (Scalar)std::pow(10, precision);
+    RectI r = ScaleRect<Integer, Scalar>(rect, scale);
+    RectClipI rc(r);
+    PathsI pp = ScalePaths<Integer, Scalar>(paths, scale, error_code);
+    if (error_code) return PathsS(); // ie: error_code result is lost
+    return ScalePaths<Scalar, Integer>(
       rc.Execute(pp), 1 / scale, error_code);
   }
 
-  inline PathsD RectClip(const RectD& rect, const PathD& path, int precision = 2)
+  inline PathsS RectClip(const RectS& rect, const PathS& path, int precision = 2)
   {
-    return RectClip(rect, PathsD{ path }, precision);
+    return RectClip(rect, PathsS{ path }, precision);
   }
 
-  inline Paths64 RectClipLines(const Rect64& rect, const Paths64& lines)
+  inline PathsI RectClipLines(const RectI& rect, const PathsI& lines)
   {
-    if (rect.IsEmpty() || lines.empty()) return Paths64();
-    RectClipLines64 rcl(rect);
+    if (rect.IsEmpty() || lines.empty()) return PathsI();
+    RectClipLinesI rcl(rect);
     return rcl.Execute(lines);
   }
 
-  inline Paths64 RectClipLines(const Rect64& rect, const Path64& line)
+  inline PathsI RectClipLines(const RectI& rect, const PathI& line)
   {
-    return RectClipLines(rect, Paths64{ line });
+    return RectClipLines(rect, PathsI{ line });
   }
 
-  inline PathsD RectClipLines(const RectD& rect, const PathsD& lines, int precision = 2)
+  inline PathsS RectClipLines(const RectS& rect, const PathsS& lines, int precision = 2)
   {
-    if (rect.IsEmpty() || lines.empty()) return PathsD();
+    if (rect.IsEmpty() || lines.empty()) return PathsS();
     int error_code = 0;
     CheckPrecisionRange(precision, error_code);
-    if (error_code) return PathsD();
-    const double scale = std::pow(10, precision);
-    Rect64 r = ScaleRect<int64_t, double>(rect, scale);
-    RectClipLines64 rcl(r);
-    Paths64 p = ScalePaths<int64_t, double>(lines, scale, error_code);
-    if (error_code) return PathsD();
+    if (error_code) return PathsS();
+    const Scalar scale = (Scalar)std::pow(10, precision);
+    RectI r = ScaleRect<Integer, Scalar>(rect, scale);
+    RectClipLinesI rcl(r);
+    PathsI p = ScalePaths<Integer, Scalar>(lines, scale, error_code);
+    if (error_code) return PathsS();
     p = rcl.Execute(p);
-    return ScalePaths<double, int64_t>(p, 1 / scale, error_code);
+    return ScalePaths<Scalar, Integer>(p, 1 / scale, error_code);
   }
 
-  inline PathsD RectClipLines(const RectD& rect, const PathD& line, int precision = 2)
+  inline PathsS RectClipLines(const RectS& rect, const PathS& line, int precision = 2)
   {
-    return RectClipLines(rect, PathsD{ line }, precision);
+    return RectClipLines(rect, PathsS{ line }, precision);
   }
 
   namespace details
   {
 
-    inline void PolyPathToPaths64(const PolyPath64& polypath, Paths64& paths)
+    inline void PolyPathToPathsI(const PolyPathI& polypath, PathsI& paths)
     {
       paths.push_back(polypath.Polygon());
       for (const auto& child : polypath)
-        PolyPathToPaths64(*child, paths);
+        PolyPathToPathsI(*child, paths);
     }
 
-    inline void PolyPathToPathsD(const PolyPathD& polypath, PathsD& paths)
+    inline void PolyPathToPathsS(const PolyPathS& polypath, PathsS& paths)
     {
       paths.push_back(polypath.Polygon());
       for (const auto& child : polypath)
-        PolyPathToPathsD(*child, paths);
+        PolyPathToPathsS(*child, paths);
     }
 
-    inline bool PolyPath64ContainsChildren(const PolyPath64& pp)
+    inline bool PolyPathIContainsChildren(const PolyPathI& pp)
     {
       for (const auto& child : pp)
       {
@@ -295,7 +295,7 @@ namespace Clipper2Lib {
         // for consecutive vertices found outside the parent's polygon.
 
         int outsideCnt = 0;
-        for (const Point64& pt : child->Polygon())
+        for (const PointI& pt : child->Polygon())
         {
           PointInPolygonResult result = PointInPolygon(pt, pp.Polygon());
           if (result == PointInPolygonResult::IsInside) --outsideCnt;
@@ -305,7 +305,7 @@ namespace Clipper2Lib {
         }
 
         // now check any nested children too
-        if (child->Count() > 0 && !PolyPath64ContainsChildren(*child))
+        if (child->Count() > 0 && !PolyPathIContainsChildren(*child))
           return false;
       }
       return true;
@@ -323,22 +323,22 @@ namespace Clipper2Lib {
           " hole" << plural << std::endl;
     }
 
-    static void OutlinePolyPath64(std::ostream& os, const PolyPath64& pp,
+    static void OutlinePolyPathI(std::ostream& os, const PolyPathI& pp,
       size_t idx, std::string preamble)
     {
       OutlinePolyPath(os, idx, pp.IsHole(), pp.Count(), preamble);
       for (size_t i = 0; i < pp.Count(); ++i)
         if (pp.Child(i)->Count())
-          details::OutlinePolyPath64(os, *pp.Child(i), i, preamble + "  ");
+          details::OutlinePolyPathI(os, *pp.Child(i), i, preamble + "  ");
     }
 
-    static void OutlinePolyPathD(std::ostream& os, const PolyPathD& pp,
+    static void OutlinePolyPathS(std::ostream& os, const PolyPathS& pp,
       size_t idx, std::string preamble)
     {
       OutlinePolyPath(os, idx, pp.IsHole(), pp.Count(), preamble);
       for (size_t i = 0; i < pp.Count(); ++i)
         if (pp.Child(i)->Count())
-          details::OutlinePolyPathD(os, *pp.Child(i), i, preamble + "  ");
+          details::OutlinePolyPathS(os, *pp.Child(i), i, preamble + "  ");
     }
 
     template<typename T, typename U>
@@ -356,13 +356,13 @@ namespace Clipper2Lib {
 
   } // end details namespace
 
-  inline std::ostream& operator<< (std::ostream& os, const PolyTree64& pp)
+  inline std::ostream& operator<< (std::ostream& os, const PolyTreeI& pp)
   {
     std::string plural = (pp.Count() == 1) ? " polygon." : " polygons.";
     os << std::endl << "Polytree with " << pp.Count() << plural << std::endl;
       for (size_t i = 0; i < pp.Count(); ++i)
         if (pp.Child(i)->Count())
-          details::OutlinePolyPath64(os, *pp.Child(i), i, "  ");
+          details::OutlinePolyPathI(os, *pp.Child(i), i, "  ");
     os << std::endl << std::endl;
     return os;
   }
@@ -373,33 +373,33 @@ namespace Clipper2Lib {
     os << std::endl << "Polytree with " << pp.Count() << plural << std::endl;
     for (size_t i = 0; i < pp.Count(); ++i)
       if (pp.Child(i)->Count())
-        details::OutlinePolyPathD(os, *pp.Child(i), i, "  ");
+        details::OutlinePolyPathS(os, *pp.Child(i), i, "  ");
     os << std::endl << std::endl;
     if (!pp.Level()) os << std::endl;
     return os;
   }
 
-  inline Paths64 PolyTreeToPaths64(const PolyTree64& polytree)
+  inline PathsI PolyTreeToPathsI(const PolyTreeI& polytree)
   {
-    Paths64 result;
+    PathsI result;
     for (const auto& child : polytree)
-      details::PolyPathToPaths64(*child, result);
+      details::PolyPathToPathsI(*child, result);
     return result;
   }
 
-  inline PathsD PolyTreeToPathsD(const PolyTreeD& polytree)
+  inline PathsS PolyTreeToPathsS(const PolyTreeD& polytree)
   {
-    PathsD result;
+    PathsS result;
     for (const auto& child : polytree)
-      details::PolyPathToPathsD(*child, result);
+      details::PolyPathToPathsS(*child, result);
     return result;
   }
 
-  inline bool CheckPolytreeFullyContainsChildren(const PolyTree64& polytree)
+  inline bool CheckPolytreeFullyContainsChildren(const PolyTreeI& polytree)
   {
     for (const auto& child : polytree)
       if (child->Count() > 0 &&
-        !details::PolyPath64ContainsChildren(*child))
+        !details::PolyPathIContainsChildren(*child))
           return false;
     return true;
   }
@@ -409,12 +409,12 @@ namespace Clipper2Lib {
       std::is_integral<T>::value &&
       !std::is_same<char, T>::value, bool
     >::type = true>
-  inline Path64 MakePath(const std::vector<T>& list)
+  inline PathI MakePath(const std::vector<T>& list)
   {
     const auto size = list.size() - list.size() % 2;
     if (list.size() != size)
       DoError(non_pair_error_i);  // non-fatal without exception handling
-    Path64 result;
+    PathI result;
     details::MakePathGeneric(list, size, result);
     return result;
   }
@@ -424,11 +424,11 @@ namespace Clipper2Lib {
       std::is_integral<T>::value &&
       !std::is_same<char, T>::value, bool
     >::type = true>
-  inline Path64 MakePath(const T(&list)[N])
+  inline PathI MakePath(const T(&list)[N])
   {
     // Make the compiler error on unpaired value (i.e. no runtime effects).
     static_assert(N % 2 == 0, "MakePath requires an even number of arguments");
-    Path64 result;
+    PathI result;
     details::MakePathGeneric(list, N, result);
     return result;
   }
@@ -438,12 +438,12 @@ namespace Clipper2Lib {
       std::is_arithmetic<T>::value &&
       !std::is_same<char, T>::value, bool
     >::type = true>
-  inline PathD MakePathD(const std::vector<T>& list)
+  inline PathS MakePathS(const std::vector<T>& list)
   {
     const auto size = list.size() - list.size() % 2;
     if (list.size() != size)
       DoError(non_pair_error_i);  // non-fatal without exception handling
-    PathD result;
+    PathS result;
     details::MakePathGeneric(list, size, result);
     return result;
   }
@@ -453,60 +453,60 @@ namespace Clipper2Lib {
       std::is_arithmetic<T>::value &&
       !std::is_same<char, T>::value, bool
     >::type = true>
-  inline PathD MakePathD(const T(&list)[N])
+  inline PathS MakePathS(const T(&list)[N])
   {
     // Make the compiler error on unpaired value (i.e. no runtime effects).
     static_assert(N % 2 == 0, "MakePath requires an even number of arguments");
-    PathD result;
+    PathS result;
     details::MakePathGeneric(list, N, result);
     return result;
   }
 
 #ifdef USINGZ
   template<typename T2, std::size_t N>
-  inline Path64 MakePathZ(const T2(&list)[N])
+  inline PathI MakePathZ(const T2(&list)[N])
   {
     static_assert(N % 3 == 0 && std::numeric_limits<T2>::is_integer,
       "MakePathZ requires integer values in multiples of 3");
     std::size_t size = N / 3;
-    Path64 result(size);
+    PathI result(size);
     for (size_t i = 0; i < size; ++i)
-      result[i] = Point64(list[i * 3],
+      result[i] = PointI(list[i * 3],
         list[i * 3 + 1], list[i * 3 + 2]);
     return result;
   }
 
   template<typename T2, std::size_t N>
-  inline PathD MakePathZD(const T2(&list)[N])
+  inline PathS MakePathZS(const T2(&list)[N])
   {
     static_assert(N % 3 == 0,
-      "MakePathZD requires values in multiples of 3");
+      "MakePathZS requires values in multiples of 3");
     std::size_t size = N / 3;
-    PathD result(size);
+    PathS result(size);
     if constexpr (std::numeric_limits<T2>::is_integer)
       for (size_t i = 0; i < size; ++i)
-        result[i] = PointD(list[i * 3],
+        result[i] = PointS(list[i * 3],
           list[i * 3 + 1], list[i * 3 + 2]);
     else
       for (size_t i = 0; i < size; ++i)
-        result[i] = PointD(list[i * 3], list[i * 3 + 1],
-          static_cast<int64_t>(list[i * 3 + 2]));
+        result[i] = PointS(list[i * 3], list[i * 3 + 1],
+          static_cast<Integer>(list[i * 3 + 2]));
     return result;
   }
 #endif
 
-  inline Path64 TrimCollinear(const Path64& p, bool is_open_path = false)
+  inline PathI TrimCollinear(const PathI& p, bool is_open_path = false)
   {
     size_t len = p.size();
     if (len < 3)
     {
-      if (!is_open_path || len < 2 || p[0] == p[1]) return Path64();
+      if (!is_open_path || len < 2 || p[0] == p[1]) return PathI();
       else return p;
     }
 
-    Path64 dst;
+    PathI dst;
     dst.reserve(len);
-    Path64::const_iterator srcIt = p.cbegin(), prevIt, stop = p.cend() - 1;
+    PathI::const_iterator srcIt = p.cbegin(), prevIt, stop = p.cend() - 1;
 
     if (!is_open_path)
     {
@@ -514,7 +514,7 @@ namespace Clipper2Lib {
         ++srcIt;
       while (srcIt != stop && IsCollinear(*(stop - 1), *stop, *srcIt))
         --stop;
-      if (srcIt == stop) return Path64();
+      if (srcIt == stop) return PathI();
     }
 
     prevIt = srcIt++;
@@ -537,33 +537,33 @@ namespace Clipper2Lib {
       while (dst.size() > 2 &&
         IsCollinear(dst[dst.size() - 1], dst[dst.size() - 2], dst[0]))
           dst.pop_back();
-      if (dst.size() < 3) return Path64();
+      if (dst.size() < 3) return PathI();
     }
     return dst;
   }
 
-  inline PathD TrimCollinear(const PathD& path, int precision, bool is_open_path = false)
+  inline PathS TrimCollinear(const PathS& path, int precision, bool is_open_path = false)
   {
     int error_code = 0;
     CheckPrecisionRange(precision, error_code);
-    if (error_code) return PathD();
-    const double scale = std::pow(10, precision);
-    Path64 p = ScalePath<int64_t, double>(path, scale, error_code);
-    if (error_code) return PathD();
+    if (error_code) return PathS();
+    const Scalar scale = (Scalar)std::pow(10, precision);
+    PathI p = ScalePath<Integer, Scalar>(path, scale, error_code);
+    if (error_code) return PathS();
     p = TrimCollinear(p, is_open_path);
-    return ScalePath<double, int64_t>(p, 1/scale, error_code);
+    return ScalePath<Scalar, Integer>(p, 1/scale, error_code);
   }
 
   template <typename T>
-  inline double Distance(const Point<T> pt1, const Point<T> pt2)
+  inline Scalar Distance(const Point<T> pt1, const Point<T> pt2)
   {
     return std::sqrt(DistanceSqr(pt1, pt2));
   }
 
   template <typename T>
-  inline double Length(const Path<T>& path, bool is_closed_path = false)
+  inline Scalar Length(const Path<T>& path, bool is_closed_path = false)
   {
-    double result = 0.0;
+    Scalar result = 0.0;
     if (path.size() < 2) return result;
     auto it = path.cbegin(), stop = path.end() - 1;
     for (; it != stop; ++it)
@@ -575,9 +575,9 @@ namespace Clipper2Lib {
 
 
   template <typename T>
-  inline bool NearCollinear(const Point<T>& pt1, const Point<T>& pt2, const Point<T>& pt3, double sin_sqrd_min_angle_rads)
+  inline bool NearCollinear(const Point<T>& pt1, const Point<T>& pt2, const Point<T>& pt3, Scalar sin_sqrd_min_angle_rads)
   {
-    double cp = std::abs(CrossProduct(pt1, pt2, pt3));
+    Scalar cp = std::abs(CrossProduct(pt1, pt2, pt3));
     return (cp * cp) / (DistanceSqr(pt1, pt2) * DistanceSqr(pt2, pt3)) < sin_sqrd_min_angle_rads;
   }
 
@@ -585,29 +585,29 @@ namespace Clipper2Lib {
   inline Path<T> Ellipse(const Rect<T>& rect, int steps = 0)
   {
     return Ellipse(rect.MidPoint(),
-      static_cast<double>(rect.Width()) *0.5,
-      static_cast<double>(rect.Height()) * 0.5, steps);
+      static_cast<Scalar>(rect.Width()) *0.5,
+      static_cast<Scalar>(rect.Height()) * 0.5, steps);
   }
 
   template <typename T>
   inline Path<T> Ellipse(const Point<T>& center,
-    double radiusX, double radiusY = 0, int steps = 0)
+    Scalar radiusX, Scalar radiusY = 0, int steps = 0)
   {
     if (radiusX <= 0) return Path<T>();
     if (radiusY <= 0) radiusY = radiusX;
     if (steps <= 2)
       steps = static_cast<int>(PI * sqrt((radiusX + radiusY) / 2));
 
-    double si = std::sin(2 * PI / steps);
-    double co = std::cos(2 * PI / steps);
-    double dx = co, dy = si;
+    Scalar si = std::sin(2 * PI / steps);
+    Scalar co = std::cos(2 * PI / steps);
+    Scalar dx = co, dy = si;
     Path<T> result;
     result.reserve(steps);
-    result.push_back(Point<T>(center.x + radiusX, static_cast<double>(center.y)));
+    result.push_back(Point<T>(center.x + radiusX, static_cast<Scalar>(center.y)));
     for (int i = 1; i < steps; ++i)
     {
       result.push_back(Point<T>(center.x + radiusX * dx, center.y + radiusY * dy));
-      double x = dx * co - dy * si;
+      Scalar x = dx * co - dy * si;
       dy = dy * co + dx * si;
       dx = x;
     }
@@ -639,14 +639,14 @@ namespace Clipper2Lib {
 
   template <typename T>
   inline Path<T> SimplifyPath(const Path<T> &path,
-    double epsilon, bool isClosedPath = true)
+    Scalar epsilon, bool isClosedPath = true)
   {
     const size_t len = path.size(), high = len -1;
-    const double epsSqr = Sqr(epsilon);
+    const Scalar epsSqr = Sqr(epsilon);
     if (len < 4) return Path<T>(path);
 
     std::vector<bool> flags(len);
-    std::vector<double> distSqr(len);
+    std::vector<Scalar> distSqr(len);
     size_t prior = high, curr = 0, start, next, prior2;
     if (isClosedPath)
     {
@@ -655,8 +655,8 @@ namespace Clipper2Lib {
     }
     else
     {
-      distSqr[0] = MAX_DBL;
-      distSqr[high] = MAX_DBL;
+      distSqr[0] = MAX_SCALAR;
+      distSqr[high] = MAX_SCALAR;
     }
     for (size_t i = 1; i < high; ++i)
       distSqr[i] = PerpendicDistFromLineSqrd(path[i], path[i - 1], path[i + 1]);
@@ -706,7 +706,7 @@ namespace Clipper2Lib {
 
   template <typename T>
   inline Paths<T> SimplifyPaths(const Paths<T> &paths,
-    double epsilon, bool isClosedPath = true)
+    Scalar epsilon, bool isClosedPath = true)
   {
     Paths<T> result;
     result.reserve(paths.size());
@@ -717,15 +717,15 @@ namespace Clipper2Lib {
 
   template <typename T>
   inline void RDP(const Path<T> path, std::size_t begin,
-    std::size_t end, double epsSqrd, std::vector<bool>& flags)
+    std::size_t end, Scalar epsSqrd, std::vector<bool>& flags)
   {
     typename Path<T>::size_type idx = 0;
-    double max_d = 0;
+    Scalar max_d = 0;
     while (end > begin && path[begin] == path[end]) flags[end--] = false;
     for (typename Path<T>::size_type i = begin + 1; i < end; ++i)
     {
       // PerpendicDistFromLineSqrd - avoids expensive Sqrt()
-      double d = PerpendicDistFromLineSqrd(path[i], path[begin], path[end]);
+      Scalar d = PerpendicDistFromLineSqrd(path[i], path[begin], path[end]);
       if (d <= max_d) continue;
       max_d = d;
       idx = i;
@@ -737,7 +737,7 @@ namespace Clipper2Lib {
   }
 
   template <typename T>
-  inline Path<T> RamerDouglasPeucker(const Path<T>& path, double epsilon)
+  inline Path<T> RamerDouglasPeucker(const Path<T>& path, Scalar epsilon)
   {
     const typename Path<T>::size_type len = path.size();
     if (len < 5) return Path<T>(path);
@@ -754,7 +754,7 @@ namespace Clipper2Lib {
   }
 
   template <typename T>
-  inline Paths<T> RamerDouglasPeucker(const Paths<T>& paths, double epsilon)
+  inline Paths<T> RamerDouglasPeucker(const Paths<T>& paths, Scalar epsilon)
   {
     Paths<T> result;
     result.reserve(paths.size());

--- a/CPP/Clipper2Lib/include/clipper2/clipper.minkowski.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.minkowski.h
@@ -20,43 +20,43 @@ namespace Clipper2Lib
 
   namespace detail
   {
-    inline Paths64 Minkowski(const Path64& pattern, const Path64& path, bool isSum, bool isClosed)
+    inline PathsI Minkowski(const PathI& pattern, const PathI& path, bool isSum, bool isClosed)
     {
       size_t delta = isClosed ? 0 : 1;
       size_t patLen = pattern.size(), pathLen = path.size();
-      if (patLen == 0 || pathLen == 0) return Paths64();
-      Paths64 tmp;
+      if (patLen == 0 || pathLen == 0) return PathsI();
+      PathsI tmp;
       tmp.reserve(pathLen);
 
       if (isSum)
       {
-        for (const Point64& p : path)
+        for (const PointI& p : path)
         {
-          Path64 path2(pattern.size());
+          PathI path2(pattern.size());
           std::transform(pattern.cbegin(), pattern.cend(),
-            path2.begin(), [p](const Point64& pt2) {return p + pt2; });
+            path2.begin(), [p](const PointI& pt2) {return p + pt2; });
           tmp.push_back(path2);
         }
       }
       else
       {
-        for (const Point64& p : path)
+        for (const PointI& p : path)
         {
-          Path64 path2(pattern.size());
+          PathI path2(pattern.size());
           std::transform(pattern.cbegin(), pattern.cend(),
-            path2.begin(), [p](const Point64& pt2) {return p - pt2; });
+            path2.begin(), [p](const PointI& pt2) {return p - pt2; });
           tmp.push_back(path2);
         }
       }
 
-      Paths64 result;
+      PathsI result;
       result.reserve((pathLen - delta) * patLen);
       size_t g = isClosed ? pathLen - 1 : 0;
       for (size_t h = patLen - 1, i = delta; i < pathLen; ++i)
       {
         for (size_t j = 0; j < patLen; j++)
         {
-          Path64 quad;
+          PathI quad;
           quad.reserve(4);
           {
             quad.push_back(tmp[g][h]);
@@ -74,10 +74,10 @@ namespace Clipper2Lib
       return result;
     }
 
-    inline Paths64 Union(const Paths64& subjects, FillRule fillrule)
+    inline PathsI Union(const PathsI& subjects, FillRule fillrule)
     {
-      Paths64 result;
-      Clipper64 clipper;
+      PathsI result;
+      ClipperI clipper;
       clipper.AddSubject(subjects);
       clipper.Execute(ClipType::Union, fillrule, result);
       return result;
@@ -85,34 +85,34 @@ namespace Clipper2Lib
 
   } // namespace internal
 
-  inline Paths64 MinkowskiSum(const Path64& pattern, const Path64& path, bool isClosed)
+  inline PathsI MinkowskiSum(const PathI& pattern, const PathI& path, bool isClosed)
   {
     return detail::Union(detail::Minkowski(pattern, path, true, isClosed), FillRule::NonZero);
   }
 
-  inline PathsD MinkowskiSum(const PathD& pattern, const PathD& path, bool isClosed, int decimalPlaces = 2)
+  inline PathsS MinkowskiSum(const PathS& pattern, const PathS& path, bool isClosed, int decimalPlaces = 2)
   {
     int error_code = 0;
-    double scale = pow(10, decimalPlaces);
-    Path64 pat64 = ScalePath<int64_t, double>(pattern, scale, error_code);
-    Path64 path64 = ScalePath<int64_t, double>(path, scale, error_code);
-    Paths64 tmp = detail::Union(detail::Minkowski(pat64, path64, true, isClosed), FillRule::NonZero);
-    return ScalePaths<double, int64_t>(tmp, 1 / scale, error_code);
+    Scalar scale = (Scalar)pow(10, decimalPlaces);
+    PathI pat64 = ScalePath<Integer, Scalar>(pattern, scale, error_code);
+    PathI path64 = ScalePath<Integer, Scalar>(path, scale, error_code);
+    PathsI tmp = detail::Union(detail::Minkowski(pat64, path64, true, isClosed), FillRule::NonZero);
+    return ScalePaths<Scalar, Integer>(tmp, 1 / scale, error_code);
   }
 
-  inline Paths64 MinkowskiDiff(const Path64& pattern, const Path64& path, bool isClosed)
+  inline PathsI MinkowskiDiff(const PathI& pattern, const PathI& path, bool isClosed)
   {
     return detail::Union(detail::Minkowski(pattern, path, false, isClosed), FillRule::NonZero);
   }
 
-  inline PathsD MinkowskiDiff(const PathD& pattern, const PathD& path, bool isClosed, int decimalPlaces = 2)
+  inline PathsS MinkowskiDiff(const PathS& pattern, const PathS& path, bool isClosed, int decimalPlaces = 2)
   {
     int error_code = 0;
-    double scale = pow(10, decimalPlaces);
-    Path64 pat64 = ScalePath<int64_t, double>(pattern, scale, error_code);
-    Path64 path64 = ScalePath<int64_t, double>(path, scale, error_code);
-    Paths64 tmp = detail::Union(detail::Minkowski(pat64, path64, false, isClosed), FillRule::NonZero);
-    return ScalePaths<double, int64_t>(tmp, 1 / scale, error_code);
+    Scalar scale = (Scalar)pow(10, decimalPlaces);
+    PathI pat64 = ScalePath<Integer, Scalar>(pattern, scale, error_code);
+    PathI path64 = ScalePath<Integer, Scalar>(path, scale, error_code);
+    PathsI tmp = detail::Union(detail::Minkowski(pat64, path64, false, isClosed), FillRule::NonZero);
+    return ScalePaths<Scalar, Integer>(tmp, 1 / scale, error_code);
   }
 
 } // Clipper2Lib namespace

--- a/CPP/Clipper2Lib/include/clipper2/clipper.offset.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.offset.h
@@ -26,63 +26,63 @@ enum class EndType {Polygon, Joined, Butt, Square, Round};
 //Joined : offsets both sides of a path, with joined ends
 //Polygon: offsets only one side of a closed path
 
-typedef std::function<double(const Path64& path, const PathD& path_normals, size_t curr_idx, size_t prev_idx)> DeltaCallback64;
+typedef std::function<Scalar(const PathI& path, const PathS& path_normals, size_t curr_idx, size_t prev_idx)> DeltaCallback64;
 
 class ClipperOffset {
 private:
 
 	class Group {
 	public:
-		Paths64 paths_in;
+		PathsI paths_in;
 		int lowest_path_idx = -1;
 		bool is_reversed = false;
 		JoinType join_type;
 		EndType end_type;
-		Group(const Paths64& _paths, JoinType _join_type, EndType _end_type);
+		Group(const PathsI& _paths, JoinType _join_type, EndType _end_type);
 	};
 
 	int   error_code_ = 0;
-	double delta_ = 0.0;
-	double group_delta_ = 0.0;
-	double temp_lim_ = 0.0;
-	double steps_per_rad_ = 0.0;
-	double step_sin_ = 0.0;
-	double step_cos_ = 0.0;
-	PathD norms;
-	Path64 path_out;
-	Paths64* solution = nullptr;
-	PolyTree64* solution_tree = nullptr;
+	Scalar delta_ = 0.0;
+	Scalar group_delta_ = 0.0;
+	Scalar temp_lim_ = 0.0;
+	Scalar steps_per_rad_ = 0.0;
+	Scalar step_sin_ = 0.0;
+	Scalar step_cos_ = 0.0;
+	PathS norms;
+	PathI path_out;
+	PathsI* solution = nullptr;
+	PolyTreeI* solution_tree = nullptr;
 	std::vector<Group> groups_;
 	JoinType join_type_ = JoinType::Bevel;
 	EndType end_type_ = EndType::Polygon;
 
-	double miter_limit_ = 0.0;
-	double arc_tolerance_ = 0.0;
+	Scalar miter_limit_ = (Scalar)0.0;
+	Scalar arc_tolerance_ = (Scalar)0.0;
 	bool preserve_collinear_ = false;
 	bool reverse_solution_ = false;
 
 #ifdef USINGZ
-	ZCallback64 zCallback64_ = nullptr;
-	void ZCB(const Point64& bot1, const Point64& top1,
-		const Point64& bot2, const Point64& top2, Point64& ip);
+	ZCallbackI zCallback64_ = nullptr;
+	void ZCB(const PointI& bot1, const PointI& top1,
+		const PointI& bot2, const PointI& top2, PointI& ip);
 #endif
 	DeltaCallback64 deltaCallback64_ = nullptr;
 	size_t CalcSolutionCapacity();
 	bool CheckReverseOrientation();
-	void DoBevel(const Path64& path, size_t j, size_t k);
-	void DoSquare(const Path64& path, size_t j, size_t k);
-	void DoMiter(const Path64& path, size_t j, size_t k, double cos_a);
-	void DoRound(const Path64& path, size_t j, size_t k, double angle);
-	void BuildNormals(const Path64& path);
-	void OffsetPolygon(Group& group, const Path64& path);
-	void OffsetOpenJoined(Group& group, const Path64& path);
-	void OffsetOpenPath(Group& group, const Path64& path);
-	void OffsetPoint(Group& group, const Path64& path, size_t j, size_t k);
+	void DoBevel(const PathI& path, size_t j, size_t k);
+	void DoSquare(const PathI& path, size_t j, size_t k);
+	void DoMiter(const PathI& path, size_t j, size_t k, Scalar cos_a);
+	void DoRound(const PathI& path, size_t j, size_t k, Scalar angle);
+	void BuildNormals(const PathI& path);
+	void OffsetPolygon(Group& group, const PathI& path);
+	void OffsetOpenJoined(Group& group, const PathI& path);
+	void OffsetOpenPath(Group& group, const PathI& path);
+	void OffsetPoint(Group& group, const PathI& path, size_t j, size_t k);
 	void DoGroupOffset(Group &group);
-	void ExecuteInternal(double delta);
+	void ExecuteInternal(Scalar delta);
 public:
-	explicit ClipperOffset(double miter_limit = 2.0,
-		double arc_tolerance = 0.0,
+	explicit ClipperOffset(Scalar miter_limit = 2.0,
+		Scalar arc_tolerance = 0.0,
 		bool preserve_collinear = false,
 		bool reverse_solution = false) :
 		miter_limit_(miter_limit), arc_tolerance_(arc_tolerance),
@@ -92,20 +92,20 @@ public:
 	~ClipperOffset() { Clear(); };
 
 	int ErrorCode() const { return error_code_; };
-	void AddPath(const Path64& path, JoinType jt_, EndType et_);
-	void AddPaths(const Paths64& paths, JoinType jt_, EndType et_);
+	void AddPath(const PathI& path, JoinType jt_, EndType et_);
+	void AddPaths(const PathsI& paths, JoinType jt_, EndType et_);
 	void Clear() { groups_.clear(); norms.clear(); };
 	
-	void Execute(double delta, Paths64& paths);
-	void Execute(double delta, PolyTree64& polytree);
-	void Execute(DeltaCallback64 delta_cb, Paths64& paths);
+	void Execute(Scalar delta, PathsI& paths);
+	void Execute(Scalar delta, PolyTreeI& polytree);
+	void Execute(DeltaCallback64 delta_cb, PathsI& paths);
 
-	double MiterLimit() const { return miter_limit_; }
-	void MiterLimit(double miter_limit) { miter_limit_ = miter_limit; }
+	Scalar MiterLimit() const { return miter_limit_; }
+	void MiterLimit(Scalar miter_limit) { miter_limit_ = miter_limit; }
 
 	//ArcTolerance: needed for rounded offsets (See offset_triginometry2.svg)
-	double ArcTolerance() const { return arc_tolerance_; }
-	void ArcTolerance(double arc_tolerance) { arc_tolerance_ = arc_tolerance; }
+	Scalar ArcTolerance() const { return arc_tolerance_; }
+	void ArcTolerance(Scalar arc_tolerance) { arc_tolerance_ = arc_tolerance; }
 
 	bool PreserveCollinear() const { return preserve_collinear_; }
 	void PreserveCollinear(bool preserve_collinear){preserve_collinear_ = preserve_collinear;}
@@ -114,7 +114,7 @@ public:
 	void ReverseSolution(bool reverse_solution) {reverse_solution_ = reverse_solution;}
 
 #ifdef USINGZ
-	void SetZCallback(ZCallback64 cb) { zCallback64_ = cb; }
+	void SetZCallback(ZCallbackI cb) { zCallback64_ = cb; }
 #endif
 	void SetDeltaCallback(DeltaCallback64 cb) { deltaCallback64_ = cb; }
 

--- a/CPP/Clipper2Lib/include/clipper2/clipper.rectclip.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.rectclip.h
@@ -25,7 +25,7 @@ namespace Clipper2Lib
 
   class OutPt2 {
   public:
-    Point64 pt;
+    PointI pt;
     size_t owner_idx;
     OutPt2List* edge;
     OutPt2* next;
@@ -33,48 +33,48 @@ namespace Clipper2Lib
   };
 
   //------------------------------------------------------------------------------
-  // RectClip64
+  // RectClipI
   //------------------------------------------------------------------------------
 
-  class RectClip64 {
+  class RectClipI {
   private:
-    void ExecuteInternal(const Path64& path);
-    Path64 GetPath(OutPt2*& op);
+    void ExecuteInternal(const PathI& path);
+    PathI GetPath(OutPt2*& op);
   protected:
-    const Rect64 rect_;
-    const Path64 rect_as_path_;
-    const Point64 rect_mp_;
-    Rect64 path_bounds_;
+    const RectI rect_;
+    const PathI rect_as_path_;
+    const PointI rect_mp_;
+    RectI path_bounds_;
     std::deque<OutPt2> op_container_;
     OutPt2List results_;  // each path can be broken into multiples
     OutPt2List edges_[8]; // clockwise and counter-clockwise
     std::vector<Location> start_locs_;
     void CheckEdges();
     void TidyEdges(int idx, OutPt2List& cw, OutPt2List& ccw);
-    void GetNextLocation(const Path64& path,
+    void GetNextLocation(const PathI& path,
       Location& loc, int& i, int highI);
-    OutPt2* Add(Point64 pt, bool start_new = false);
+    OutPt2* Add(PointI pt, bool start_new = false);
     void AddCorner(Location prev, Location curr);
     void AddCorner(Location& loc, bool isClockwise);
   public:
-    explicit RectClip64(const Rect64& rect) :
+    explicit RectClipI(const RectI& rect) :
       rect_(rect),
       rect_as_path_(rect.AsPath()),
       rect_mp_(rect.MidPoint()) {}
-    Paths64 Execute(const Paths64& paths);
+    PathsI Execute(const PathsI& paths);
   };
 
   //------------------------------------------------------------------------------
-  // RectClipLines64
+  // RectClipLinesI
   //------------------------------------------------------------------------------
 
-  class RectClipLines64 : public RectClip64 {
+  class RectClipLinesI : public RectClipI {
   private:
-    void ExecuteInternal(const Path64& path);
-    Path64 GetPath(OutPt2*& op);
+    void ExecuteInternal(const PathI& path);
+    PathI GetPath(OutPt2*& op);
   public:
-    explicit RectClipLines64(const Rect64& rect) : RectClip64(rect) {};
-    Paths64 Execute(const Paths64& paths);
+    explicit RectClipLinesI(const RectI& rect) : RectClipI(rect) {};
+    PathsI Execute(const PathsI& paths);
   };
 
 } // Clipper2Lib namespace

--- a/CPP/Clipper2Lib/src/clipper.offset.cpp
+++ b/CPP/Clipper2Lib/src/clipper.offset.cpp
@@ -13,20 +13,20 @@
 
 namespace Clipper2Lib {
 
-const double default_arc_tolerance = 0.25;
-const double floating_point_tolerance = 1e-12;
+const Scalar default_arc_tolerance = (Scalar)0.25;
+const Scalar floating_point_tolerance = (Scalar)1e-12;
 
 //------------------------------------------------------------------------------
 // Miscellaneous methods
 //------------------------------------------------------------------------------
 
-int GetLowestClosedPathIdx(const Paths64& paths)
+int GetLowestClosedPathIdx(const PathsI& paths)
 {
 	int result = -1;
-	Point64 botPt = Point64(INT64_MAX, INT64_MIN);
+	PointI botPt = PointI(INT64_MAX, INT64_MIN);
 	for (size_t i = 0; i < paths.size(); ++i)
 	{
-		for (const Point64& pt : paths[i])
+		for (const PointI& pt : paths[i])
 		{
 			if ((pt.y < botPt.y) || 
 				((pt.y == botPt.y) && (pt.x >= botPt.x))) continue;
@@ -38,40 +38,40 @@ int GetLowestClosedPathIdx(const Paths64& paths)
 	return result;
 }
 
-PointD GetUnitNormal(const Point64& pt1, const Point64& pt2)
+PointS GetUnitNormal(const PointI& pt1, const PointI& pt2)
 {
-	double dx, dy, inverse_hypot;
-	if (pt1 == pt2) return PointD(0.0, 0.0);
-	dx = static_cast<double>(pt2.x - pt1.x);
-	dy = static_cast<double>(pt2.y - pt1.y);
-	inverse_hypot = 1.0 / hypot(dx, dy);
+	Scalar dx, dy, inverse_hypot;
+	if (pt1 == pt2) return PointS((Scalar)0.0, (Scalar)0.0);
+	dx = static_cast<Scalar>(pt2.x - pt1.x);
+	dy = static_cast<Scalar>(pt2.y - pt1.y);
+	inverse_hypot = (Scalar)1.0 / hypot(dx, dy);
 	dx *= inverse_hypot;
 	dy *= inverse_hypot;
-	return PointD(dy, -dx);
+	return PointS(dy, -dx);
 }
 
-inline bool AlmostZero(double value, double epsilon = 0.001)
+inline bool AlmostZero(Scalar value, Scalar epsilon = 0.001)
 {
 	return std::fabs(value) < epsilon;
 }
 
-inline double Hypot(double x, double y)
+inline Scalar Hypot(Scalar x, Scalar y)
 {
 	//see https://stackoverflow.com/a/32436148/359538
 	return std::sqrt(x * x + y * y);
 }
 
-inline PointD NormalizeVector(const PointD& vec)
+inline PointS NormalizeVector(const PointS& vec)
 {
-	double h = Hypot(vec.x, vec.y);
-	if (AlmostZero(h)) return PointD(0,0);
-	double inverseHypot = 1 / h;
-	return PointD(vec.x * inverseHypot, vec.y * inverseHypot);
+	Scalar h = Hypot(vec.x, vec.y);
+	if (AlmostZero(h)) return PointS(0,0);
+	Scalar inverseHypot = 1 / h;
+	return PointS(vec.x * inverseHypot, vec.y * inverseHypot);
 }
 
-inline PointD GetAvgUnitVector(const PointD& vec1, const PointD& vec2)
+inline PointS GetAvgUnitVector(const PointS& vec1, const PointS& vec2)
 {
-	return NormalizeVector(PointD(vec1.x + vec2.x, vec1.y + vec2.y));
+	return NormalizeVector(PointS(vec1.x + vec2.x, vec1.y + vec2.y));
 }
 
 inline bool IsClosedPath(EndType et)
@@ -79,27 +79,27 @@ inline bool IsClosedPath(EndType et)
 	return et == EndType::Polygon || et == EndType::Joined;
 }
 
-inline Point64 GetPerpendic(const Point64& pt, const PointD& norm, double delta)
+inline PointI GetPerpendic(const PointI& pt, const PointS& norm, Scalar delta)
 {
 #ifdef USINGZ
-	return Point64(pt.x + norm.x * delta, pt.y + norm.y * delta, pt.z);
+	return PointI(pt.x + norm.x * delta, pt.y + norm.y * delta, pt.z);
 #else
-	return Point64(pt.x + norm.x * delta, pt.y + norm.y * delta);
+	return PointI(pt.x + norm.x * delta, pt.y + norm.y * delta);
 #endif
 }
 
-inline PointD GetPerpendicD(const Point64& pt, const PointD& norm, double delta)
+inline PointS GetPerpendicD(const PointI& pt, const PointS& norm, Scalar delta)
 {
 #ifdef USINGZ
-	return PointD(pt.x + norm.x * delta, pt.y + norm.y * delta, pt.z);
+	return PointS(pt.x + norm.x * delta, pt.y + norm.y * delta, pt.z);
 #else
-	return PointD(pt.x + norm.x * delta, pt.y + norm.y * delta);
+	return PointS(pt.x + norm.x * delta, pt.y + norm.y * delta);
 #endif
 }
 
-inline void NegatePath(PathD& path)
+inline void NegatePath(PathS& path)
 {
-	for (PointD& pt : path)
+	for (PointS& pt : path)
 	{
 		pt.x = -pt.x;
 		pt.y = -pt.y;
@@ -114,13 +114,13 @@ inline void NegatePath(PathD& path)
 // ClipperOffset::Group methods
 //------------------------------------------------------------------------------
 
-ClipperOffset::Group::Group(const Paths64& _paths, JoinType _join_type, EndType _end_type):
+ClipperOffset::Group::Group(const PathsI& _paths, JoinType _join_type, EndType _end_type):
 	paths_in(_paths), join_type(_join_type), end_type(_end_type)
 {
 	bool is_joined =
 		(end_type == EndType::Polygon) ||
 		(end_type == EndType::Joined);
-	for (Path64& p: paths_in)
+	for (PathI& p: paths_in)
 	  StripDuplicates(p, is_joined);
 
 	if (end_type == EndType::Polygon)
@@ -142,153 +142,153 @@ ClipperOffset::Group::Group(const Paths64& _paths, JoinType _join_type, EndType 
 // ClipperOffset methods
 //------------------------------------------------------------------------------
 
-void ClipperOffset::AddPath(const Path64& path, JoinType jt_, EndType et_)
+void ClipperOffset::AddPath(const PathI& path, JoinType jt_, EndType et_)
 {
-	Paths64 paths;
+	PathsI paths;
 	paths.push_back(path);
 	AddPaths(paths, jt_, et_);
 }
 
-void ClipperOffset::AddPaths(const Paths64 &paths, JoinType jt_, EndType et_)
+void ClipperOffset::AddPaths(const PathsI &paths, JoinType jt_, EndType et_)
 {
 	if (paths.size() == 0) return;
 	groups_.push_back(Group(paths, jt_, et_));
 }
 
-void ClipperOffset::BuildNormals(const Path64& path)
+void ClipperOffset::BuildNormals(const PathI& path)
 {
 	norms.clear();
 	norms.reserve(path.size());
 	if (path.size() == 0) return;
-	Path64::const_iterator path_iter, path_stop_iter = --path.cend();
+	PathI::const_iterator path_iter, path_stop_iter = --path.cend();
 	for (path_iter = path.cbegin(); path_iter != path_stop_iter; ++path_iter)
 		norms.push_back(GetUnitNormal(*path_iter,*(path_iter +1)));
 	norms.push_back(GetUnitNormal(*path_stop_iter, *(path.cbegin())));
 }
 
-void ClipperOffset::DoBevel(const Path64& path, size_t j, size_t k)
+void ClipperOffset::DoBevel(const PathI& path, size_t j, size_t k)
 {
-	PointD pt1, pt2;
+	PointS pt1, pt2;
 	if (j == k)
 	{
-		double abs_delta = std::abs(group_delta_);
+		Scalar abs_delta = std::abs(group_delta_);
 #ifdef USINGZ
-		pt1 = PointD(path[j].x - abs_delta * norms[j].x, path[j].y - abs_delta * norms[j].y, path[j].z);
-		pt2 = PointD(path[j].x + abs_delta * norms[j].x, path[j].y + abs_delta * norms[j].y, path[j].z);
+		pt1 = PointS(path[j].x - abs_delta * norms[j].x, path[j].y - abs_delta * norms[j].y, path[j].z);
+		pt2 = PointS(path[j].x + abs_delta * norms[j].x, path[j].y + abs_delta * norms[j].y, path[j].z);
 #else
-		pt1 = PointD(path[j].x - abs_delta * norms[j].x, path[j].y - abs_delta * norms[j].y);
-		pt2 = PointD(path[j].x + abs_delta * norms[j].x, path[j].y + abs_delta * norms[j].y);
+		pt1 = PointS(path[j].x - abs_delta * norms[j].x, path[j].y - abs_delta * norms[j].y);
+		pt2 = PointS(path[j].x + abs_delta * norms[j].x, path[j].y + abs_delta * norms[j].y);
 #endif
 	}
 	else
 	{
 #ifdef USINGZ
-		pt1 = PointD(path[j].x + group_delta_ * norms[k].x, path[j].y + group_delta_ * norms[k].y, path[j].z);
-		pt2 = PointD(path[j].x + group_delta_ * norms[j].x, path[j].y + group_delta_ * norms[j].y, path[j].z);
+		pt1 = PointS(path[j].x + group_delta_ * norms[k].x, path[j].y + group_delta_ * norms[k].y, path[j].z);
+		pt2 = PointS(path[j].x + group_delta_ * norms[j].x, path[j].y + group_delta_ * norms[j].y, path[j].z);
 #else
-		pt1 = PointD(path[j].x + group_delta_ * norms[k].x, path[j].y + group_delta_ * norms[k].y);
-		pt2 = PointD(path[j].x + group_delta_ * norms[j].x, path[j].y + group_delta_ * norms[j].y);
+		pt1 = PointS(path[j].x + group_delta_ * norms[k].x, path[j].y + group_delta_ * norms[k].y);
+		pt2 = PointS(path[j].x + group_delta_ * norms[j].x, path[j].y + group_delta_ * norms[j].y);
 #endif
 	}
-	path_out.push_back(Point64(pt1));
-	path_out.push_back(Point64(pt2));
+	path_out.push_back(PointI(pt1));
+	path_out.push_back(PointI(pt2));
 }
 
-void ClipperOffset::DoSquare(const Path64& path, size_t j, size_t k)
+void ClipperOffset::DoSquare(const PathI& path, size_t j, size_t k)
 {
-	PointD vec;
+	PointS vec;
 	if (j == k)
-		vec = PointD(norms[j].y, -norms[j].x);
+		vec = PointS(norms[j].y, -norms[j].x);
 	else
 		vec = GetAvgUnitVector(
-			PointD(-norms[k].y, norms[k].x),
-			PointD(norms[j].y, -norms[j].x));
+			PointS(-norms[k].y, norms[k].x),
+			PointS(norms[j].y, -norms[j].x));
 
-	double abs_delta = std::abs(group_delta_);
+	Scalar abs_delta = std::abs(group_delta_);
 
 	// now offset the original vertex delta units along unit vector
-	PointD ptQ = PointD(path[j]);
+	PointS ptQ = PointS(path[j]);
 	ptQ = TranslatePoint(ptQ, abs_delta * vec.x, abs_delta * vec.y);
 	// get perpendicular vertices
-	PointD pt1 = TranslatePoint(ptQ, group_delta_ * vec.y, group_delta_ * -vec.x);
-	PointD pt2 = TranslatePoint(ptQ, group_delta_ * -vec.y, group_delta_ * vec.x);
+	PointS pt1 = TranslatePoint(ptQ, group_delta_ * vec.y, group_delta_ * -vec.x);
+	PointS pt2 = TranslatePoint(ptQ, group_delta_ * -vec.y, group_delta_ * vec.x);
 	// get 2 vertices along one edge offset
-	PointD pt3 = GetPerpendicD(path[k], norms[k], group_delta_);
+	PointS pt3 = GetPerpendicD(path[k], norms[k], group_delta_);
 	if (j == k)
 	{
-		PointD pt4 = PointD(pt3.x + vec.x * group_delta_, pt3.y + vec.y * group_delta_);
-		PointD pt = ptQ;
+		PointS pt4 = PointS(pt3.x + vec.x * group_delta_, pt3.y + vec.y * group_delta_);
+		PointS pt = ptQ;
 		GetSegmentIntersectPt(pt1, pt2, pt3, pt4, pt);
 		//get the second intersect point through reflecion
-		path_out.push_back(Point64(ReflectPoint(pt, ptQ)));
-		path_out.push_back(Point64(pt));
+		path_out.push_back(PointI(ReflectPoint(pt, ptQ)));
+		path_out.push_back(PointI(pt));
 	}
 	else
 	{
-		PointD pt4 = GetPerpendicD(path[j], norms[k], group_delta_);
-		PointD pt = ptQ;
+		PointS pt4 = GetPerpendicD(path[j], norms[k], group_delta_);
+		PointS pt = ptQ;
 		GetSegmentIntersectPt(pt1, pt2, pt3, pt4, pt);
-		path_out.push_back(Point64(pt));
+		path_out.push_back(PointI(pt));
 		//get the second intersect point through reflecion
-		path_out.push_back(Point64(ReflectPoint(pt, ptQ)));
+		path_out.push_back(PointI(ReflectPoint(pt, ptQ)));
 	}
 }
 
-void ClipperOffset::DoMiter(const Path64& path, size_t j, size_t k, double cos_a)
+void ClipperOffset::DoMiter(const PathI& path, size_t j, size_t k, Scalar cos_a)
 {
-	double q = group_delta_ / (cos_a + 1);
+	Scalar q = group_delta_ / (cos_a + 1);
 #ifdef USINGZ
-	path_out.push_back(Point64(
+	path_out.push_back(PointI(
 		path[j].x + (norms[k].x + norms[j].x) * q,
 		path[j].y + (norms[k].y + norms[j].y) * q,
 		path[j].z));
 #else
-	path_out.push_back(Point64(
+	path_out.push_back(PointI(
 		path[j].x + (norms[k].x + norms[j].x) * q,
 		path[j].y + (norms[k].y + norms[j].y) * q));
 #endif
 }
 
-void ClipperOffset::DoRound(const Path64& path, size_t j, size_t k, double angle)
+void ClipperOffset::DoRound(const PathI& path, size_t j, size_t k, Scalar angle)
 {
 	if (deltaCallback64_) {
 		// when deltaCallback64_ is assigned, group_delta_ won't be constant,
 		// so we'll need to do the following calculations for *every* vertex.
-		double abs_delta = std::fabs(group_delta_);
-		double arcTol = (arc_tolerance_ > floating_point_tolerance ?
+		Scalar abs_delta = std::fabs(group_delta_);
+		Scalar arcTol = (arc_tolerance_ > floating_point_tolerance ?
 			std::min(abs_delta, arc_tolerance_) :
 			std::log10(2 + abs_delta) * default_arc_tolerance);
-		double steps_per_360 = std::min(PI / std::acos(1 - arcTol / abs_delta), abs_delta * PI);
+		Scalar steps_per_360 = std::min(PI / std::acos(1 - arcTol / abs_delta), abs_delta * PI);
 		step_sin_ = std::sin(2 * PI / steps_per_360);
 		step_cos_ = std::cos(2 * PI / steps_per_360);
 		if (group_delta_ < 0.0) step_sin_ = -step_sin_;
 		steps_per_rad_ = steps_per_360 / (2 * PI);
 	}
 
-	Point64 pt = path[j];
-	PointD offsetVec = PointD(norms[k].x * group_delta_, norms[k].y * group_delta_);
+	PointI pt = path[j];
+	PointS offsetVec = PointS(norms[k].x * group_delta_, norms[k].y * group_delta_);
 
 	if (j == k) offsetVec.Negate();
 #ifdef USINGZ
-	path_out.push_back(Point64(pt.x + offsetVec.x, pt.y + offsetVec.y, pt.z));
+	path_out.push_back(PointI(pt.x + offsetVec.x, pt.y + offsetVec.y, pt.z));
 #else
-	path_out.push_back(Point64(pt.x + offsetVec.x, pt.y + offsetVec.y));
+	path_out.push_back(PointI(pt.x + offsetVec.x, pt.y + offsetVec.y));
 #endif
 	int steps = static_cast<int>(std::ceil(steps_per_rad_ * std::abs(angle))); // #448, #456
 	for (int i = 1; i < steps; ++i) // ie 1 less than steps
 	{
-		offsetVec = PointD(offsetVec.x * step_cos_ - step_sin_ * offsetVec.y,
+		offsetVec = PointS(offsetVec.x * step_cos_ - step_sin_ * offsetVec.y,
 			offsetVec.x * step_sin_ + offsetVec.y * step_cos_);
 #ifdef USINGZ
-		path_out.push_back(Point64(pt.x + offsetVec.x, pt.y + offsetVec.y, pt.z));
+		path_out.push_back(PointI(pt.x + offsetVec.x, pt.y + offsetVec.y, pt.z));
 #else
-		path_out.push_back(Point64(pt.x + offsetVec.x, pt.y + offsetVec.y));
+		path_out.push_back(PointI(pt.x + offsetVec.x, pt.y + offsetVec.y));
 #endif
 	}
 	path_out.push_back(GetPerpendic(path[j], norms[j], group_delta_));
 }
 
-void ClipperOffset::OffsetPoint(Group& group, const Path64& path, size_t j, size_t k)
+void ClipperOffset::OffsetPoint(Group& group, const PathI& path, size_t j, size_t k)
 {
 	// Let A = change in angle where edges join
 	// A == 0: ie no change in angle (flat join)
@@ -298,8 +298,8 @@ void ClipperOffset::OffsetPoint(Group& group, const Path64& path, size_t j, size
 
 	if (path[j] == path[k]) return;
 
-	double sin_a = CrossProduct(norms[j], norms[k]);
-	double cos_a = DotProduct(norms[j], norms[k]);
+	Scalar sin_a = CrossProduct(norms[j], norms[k]);
+	Scalar cos_a = DotProduct(norms[j], norms[k]);
 	if (sin_a > 1.0) sin_a = 1.0;
 	else if (sin_a < -1.0) sin_a = -1.0;
 
@@ -317,7 +317,7 @@ void ClipperOffset::OffsetPoint(Group& group, const Path64& path, size_t j, size
 	{
 		// is concave (so insert 3 points that will create a negative region)
 #ifdef USINGZ
-		path_out.push_back(Point64(GetPerpendic(path[j], norms[k], group_delta_), path[j].z));
+		path_out.push_back(PointI(GetPerpendic(path[j], norms[k], group_delta_), path[j].z));
 #else
 		path_out.push_back(GetPerpendic(path[j], norms[k], group_delta_));
 #endif
@@ -328,7 +328,7 @@ void ClipperOffset::OffsetPoint(Group& group, const Path64& path, size_t j, size
 		if (cos_a < 0.99) path_out.push_back(path[j]); // (#405)
 
 #ifdef USINGZ
-		path_out.push_back(Point64(GetPerpendic(path[j], norms[j], group_delta_), path[j].z));
+		path_out.push_back(PointI(GetPerpendic(path[j], norms[j], group_delta_), path[j].z));
 #else
 		path_out.push_back(GetPerpendic(path[j], norms[j], group_delta_));
 #endif
@@ -352,18 +352,18 @@ void ClipperOffset::OffsetPoint(Group& group, const Path64& path, size_t j, size
 		DoSquare(path, j, k);
 }
 
-void ClipperOffset::OffsetPolygon(Group& group, const Path64& path)
+void ClipperOffset::OffsetPolygon(Group& group, const PathI& path)
 {
 	path_out.clear();
-	for (Path64::size_type j = 0, k = path.size() - 1; j < path.size(); k = j, ++j)
+	for (PathI::size_type j = 0, k = path.size() - 1; j < path.size(); k = j, ++j)
 		OffsetPoint(group, path, j, k);	
 	solution->push_back(path_out);
 }
 
-void ClipperOffset::OffsetOpenJoined(Group& group, const Path64& path)
+void ClipperOffset::OffsetOpenJoined(Group& group, const PathI& path)
 {
 	OffsetPolygon(group, path);
-	Path64 reverse_path(path);
+	PathI reverse_path(path);
 	std::reverse(reverse_path.begin(), reverse_path.end());
 
 	//rebuild normals 
@@ -375,7 +375,7 @@ void ClipperOffset::OffsetOpenJoined(Group& group, const Path64& path)
 	OffsetPolygon(group, reverse_path);
 }
 
-void ClipperOffset::OffsetOpenPath(Group& group, const Path64& path)
+void ClipperOffset::OffsetOpenPath(Group& group, const PathI& path)
 {
 	// do the line start cap
 	if (deltaCallback64_) group_delta_ = deltaCallback64_(path, norms, 0, 0);
@@ -400,12 +400,12 @@ void ClipperOffset::OffsetOpenPath(Group& group, const Path64& path)
 
 	size_t highI = path.size() - 1;
 	// offset the left side going forward
-	for (Path64::size_type j = 1, k = 0; j < highI; k = j, ++j)
+	for (PathI::size_type j = 1, k = 0; j < highI; k = j, ++j)
 		OffsetPoint(group, path, j, k);
 
 	// reverse normals
 	for (size_t i = highI; i > 0; --i)
-		norms[i] = PointD(-norms[i - 1].x, -norms[i - 1].y);
+		norms[i] = PointS(-norms[i - 1].x, -norms[i - 1].y);
 	norms[0] = norms[highI];
 
 	// do the line end cap
@@ -447,7 +447,7 @@ void ClipperOffset::DoGroupOffset(Group& group)
 	else
 		group_delta_ = std::abs(delta_);// *0.5;
 
-	double abs_delta = std::fabs(group_delta_);
+	Scalar abs_delta = std::fabs(group_delta_);
 	join_type_	= group.join_type;
 	end_type_ = group.end_type;
 
@@ -458,22 +458,22 @@ void ClipperOffset::DoGroupOffset(Group& group)
 		// arcTol - when arc_tolerance_ is undefined (0) then curve imprecision
 		// will be relative to the size of the offset (delta). Obviously very
 		//large offsets will almost always require much less precision.
-		double arcTol = (arc_tolerance_ > floating_point_tolerance ?
+		Scalar arcTol = (arc_tolerance_ > floating_point_tolerance ?
 			std::min(abs_delta, arc_tolerance_) :
 			std::log10(2 + abs_delta) * default_arc_tolerance);
 
-		double steps_per_360 = std::min(PI / std::acos(1 - arcTol / abs_delta), abs_delta * PI);
+		Scalar steps_per_360 = std::min(PI / std::acos(1 - arcTol / abs_delta), abs_delta * PI);
 		step_sin_ = std::sin(2 * PI / steps_per_360);
 		step_cos_ = std::cos(2 * PI / steps_per_360);
 		if (group_delta_ < 0.0) step_sin_ = -step_sin_;
 		steps_per_rad_ = steps_per_360 / (2 * PI);
 	}
 
-	//double min_area = PI * Sqr(group_delta_);
-	Paths64::const_iterator path_in_it = group.paths_in.cbegin();
+	//Scalar min_area = PI * Sqr(group_delta_);
+	PathsI::const_iterator path_in_it = group.paths_in.cbegin();
 	for ( ; path_in_it != group.paths_in.cend(); ++path_in_it)
 	{
-		Path64::size_type pathLen = path_in_it->size();
+		PathI::size_type pathLen = path_in_it->size();
 		path_out.clear();
 
 		if (pathLen == 1) // single point
@@ -486,11 +486,11 @@ void ClipperOffset::DoGroupOffset(Group& group)
 			}
 
 			if (group_delta_ < 1) continue;
-			const Point64& pt = (*path_in_it)[0];
+			const PointI& pt = (*path_in_it)[0];
 			//single vertex so build a circle or square ...
 			if (group.join_type == JoinType::Round)
 			{
-				double radius = abs_delta;
+				Scalar radius = abs_delta;
 				int steps = static_cast<int>(std::ceil(steps_per_rad_ * 2 * PI)); //#617
 				path_out = Ellipse(pt, radius, radius, steps);
 #ifdef USINGZ
@@ -499,8 +499,8 @@ void ClipperOffset::DoGroupOffset(Group& group)
 			}
 			else
 			{
-				int d = (int)std::ceil(abs_delta);
-				Rect64 r = Rect64(pt.x - d, pt.y - d, pt.x + d, pt.y + d);
+				Integer d = (Integer)std::ceil(abs_delta);
+				RectI r = RectI(pt.x - d, pt.y - d, pt.x + d, pt.y + d);
 				path_out = r.AsPath();
 #ifdef USINGZ
 				for (auto& p : path_out) p.z = pt.z;
@@ -524,8 +524,8 @@ void ClipperOffset::DoGroupOffset(Group& group)
 }
 
 #ifdef USINGZ
-void ClipperOffset::ZCB(const Point64& bot1, const Point64& top1,
-	const Point64& bot2, const Point64& top2, Point64& ip)
+void ClipperOffset::ZCB(const PointI& bot1, const PointI& top1,
+	const PointI& bot2, const PointI& top2, PointI& ip)
 {
 	if (bot1.z && ((bot1.z == bot2.z) || (bot1.z == top2.z))) ip.z = bot1.z;
 	else if (bot2.z && (bot2.z == top1.z)) ip.z = bot2.z;
@@ -555,7 +555,7 @@ bool ClipperOffset::CheckReverseOrientation()
 	return is_reversed_orientation;
 }
 
-void ClipperOffset::ExecuteInternal(double delta)
+void ClipperOffset::ExecuteInternal(Scalar delta)
 {
 	error_code_ = 0;
 	if (groups_.size() == 0) return;
@@ -563,7 +563,7 @@ void ClipperOffset::ExecuteInternal(double delta)
 
 	if (std::abs(delta) < 0.5) // ie: offset is insignificant
 	{
-		Paths64::size_type sol_size = 0;
+		PathsI::size_type sol_size = 0;
 		for (const Group& group : groups_) sol_size += group.paths_in.size();
 		solution->reserve(sol_size);
 		for (const Group& group : groups_)
@@ -572,9 +572,9 @@ void ClipperOffset::ExecuteInternal(double delta)
 	else
 	{
 
-		temp_lim_ = (miter_limit_ <= 1) ?
-			2.0 :
-			2.0 / (miter_limit_ * miter_limit_);
+		temp_lim_ = (miter_limit_ <= (Scalar)1) ?
+			(Scalar)2.0 :
+			(Scalar)2.0 / (miter_limit_ * miter_limit_);
 
 		delta_ = delta;
 		std::vector<Group>::iterator git;
@@ -590,7 +590,7 @@ void ClipperOffset::ExecuteInternal(double delta)
 
 	bool paths_reversed = CheckReverseOrientation();
 	//clean up self-intersections ...
-	Clipper64 c;
+	ClipperI c;
 	c.PreserveCollinear(false);
 	//the solution should retain the orientation of the input
 	c.ReverseSolution(reverse_solution_ != paths_reversed);
@@ -617,7 +617,7 @@ void ClipperOffset::ExecuteInternal(double delta)
 	}
 }
 
-void ClipperOffset::Execute(double delta, Paths64& paths)
+void ClipperOffset::Execute(Scalar delta, PathsI& paths)
 {
 	paths.clear();
 	solution = &paths;
@@ -626,17 +626,17 @@ void ClipperOffset::Execute(double delta, Paths64& paths)
 }
 
 
-void ClipperOffset::Execute(double delta, PolyTree64& polytree)
+void ClipperOffset::Execute(Scalar delta, PolyTreeI& polytree)
 {
 	polytree.Clear();
 	solution_tree = &polytree;
-	solution = new Paths64();
+	solution = new PathsI();
 	ExecuteInternal(delta);
 	delete solution;
 	solution = nullptr;
 }
 
-void ClipperOffset::Execute(DeltaCallback64 delta_cb, Paths64& paths)
+void ClipperOffset::Execute(DeltaCallback64 delta_cb, PathsI& paths)
 {
 	deltaCallback64_ = delta_cb;
 	Execute(1.0, paths);

--- a/CPP/Clipper2Lib/src/clipper.rectclip.cpp
+++ b/CPP/Clipper2Lib/src/clipper.rectclip.cpp
@@ -17,11 +17,11 @@ namespace Clipper2Lib {
   // Miscellaneous methods
   //------------------------------------------------------------------------------
 
-  inline bool Path1ContainsPath2(const Path64& path1, const Path64& path2)
+  inline bool Path1ContainsPath2(const PathI& path1, const PathI& path2)
   {
     int io_count = 0;
     // precondition: no (significant) overlap
-    for (const Point64& pt : path2)
+    for (const PointI& pt : path2)
     {
       PointInPolygonResult pip = PointInPolygon(pt, path1);
       switch (pip)
@@ -35,8 +35,8 @@ namespace Clipper2Lib {
     return io_count <= 0;
   }
 
-  inline bool GetLocation(const Rect64& rec,
-    const Point64& pt, Location& loc)
+  inline bool GetLocation(const RectI& rec,
+    const PointI& pt, Location& loc)
   {
     if (pt.x == rec.left && pt.y >= rec.top && pt.y <= rec.bottom)
     {
@@ -66,16 +66,16 @@ namespace Clipper2Lib {
     return true;
   }
 
-  inline bool IsHorizontal(const Point64& pt1, const Point64& pt2)
+  inline bool IsHorizontal(const PointI& pt1, const PointI& pt2)
   {
     return pt1.y == pt2.y;
   }
 
-  bool GetSegmentIntersection(const Point64& p1,
-    const Point64& p2, const Point64& p3, const Point64& p4, Point64& ip)
+  bool GetSegmentIntersection(const PointI& p1,
+    const PointI& p2, const PointI& p3, const PointI& p4, PointI& ip)
   {
-    double res1 = CrossProduct(p1, p3, p4);
-    double res2 = CrossProduct(p2, p3, p4);
+    Scalar res1 = CrossProduct(p1, p3, p4);
+    Scalar res2 = CrossProduct(p2, p3, p4);
     if (res1 == 0)
     {
       ip = p1;
@@ -94,8 +94,8 @@ namespace Clipper2Lib {
     }
     if ((res1 > 0) == (res2 > 0)) return false;
 
-    double res3 = CrossProduct(p3, p1, p2);
-    double res4 = CrossProduct(p4, p1, p2);
+    Scalar res3 = CrossProduct(p3, p1, p2);
+    Scalar res4 = CrossProduct(p4, p1, p2);
     if (res3 == 0)
     {
       ip = p3;
@@ -116,8 +116,8 @@ namespace Clipper2Lib {
     return GetSegmentIntersectPt(p1, p2, p3, p4, ip);
   }
 
-  inline bool GetIntersection(const Path64& rectPath,
-    const Point64& p, const Point64& p2, Location& loc, Point64& ip)
+  inline bool GetIntersection(const PathI& rectPath,
+    const PointI& p, const PointI& p2, Location& loc, PointI& ip)
   {
     // gets the intersection closest to 'p'
     // when Result = false, loc will remain unchanged
@@ -221,7 +221,7 @@ namespace Clipper2Lib {
   }
 
   inline bool IsClockwise(Location prev, Location curr,
-    const Point64& prev_pt, const Point64& curr_pt, const Point64& rect_mp)
+    const PointI& prev_pt, const PointI& curr_pt, const PointI& rect_mp)
   {
     if (AreOpposites(prev, curr))
       return CrossProduct(prev_pt, rect_mp, curr_pt) < 0;
@@ -245,7 +245,7 @@ namespace Clipper2Lib {
     return op->prev;
   }
 
-  inline uint32_t GetEdgesForPt(const Point64& pt, const Rect64& rec)
+  inline uint32_t GetEdgesForPt(const PointI& pt, const RectI& rec)
   {
     uint32_t result = 0;
     if (pt.x == rec.left) result = 1;
@@ -255,7 +255,7 @@ namespace Clipper2Lib {
     return result;
   }
 
-  inline bool IsHeadingClockwise(const Point64& pt1, const Point64& pt2, int edgeIdx)
+  inline bool IsHeadingClockwise(const PointI& pt1, const PointI& pt2, int edgeIdx)
   {
     switch (edgeIdx)
     {
@@ -266,14 +266,14 @@ namespace Clipper2Lib {
     }
   }
 
-  inline bool HasHorzOverlap(const Point64& left1, const Point64& right1,
-    const Point64& left2, const Point64& right2)
+  inline bool HasHorzOverlap(const PointI& left1, const PointI& right1,
+    const PointI& left2, const PointI& right2)
   {
     return (left1.x < right2.x) && (right1.x > left2.x);
   }
 
-  inline bool HasVertOverlap(const Point64& top1, const Point64& bottom1,
-    const Point64& top2, const Point64& bottom2)
+  inline bool HasVertOverlap(const PointI& top1, const PointI& bottom1,
+    const PointI& top2, const PointI& bottom2)
   {
     return (top1.y < bottom2.y) && (bottom1.y > top2.y);
   }
@@ -312,10 +312,10 @@ namespace Clipper2Lib {
   }
 
   //----------------------------------------------------------------------------
-  // RectClip64
+  // RectClipI
   //----------------------------------------------------------------------------
 
-  OutPt2* RectClip64::Add(Point64 pt, bool start_new)
+  OutPt2* RectClipI::Add(PointI pt, bool start_new)
   {
     // this method is only called by InternalExecute.
     // Later splitting & rejoining won't create additional op's,
@@ -346,7 +346,7 @@ namespace Clipper2Lib {
     return result;
   }
 
-  void RectClip64::AddCorner(Location prev, Location curr)
+  void RectClipI::AddCorner(Location prev, Location curr)
   {
     if (HeadingClockwise(prev, curr))
       Add(rect_as_path_[static_cast<int>(prev)]);
@@ -354,7 +354,7 @@ namespace Clipper2Lib {
       Add(rect_as_path_[static_cast<int>(curr)]);
   }
 
-  void RectClip64::AddCorner(Location& loc, bool isClockwise)
+  void RectClipI::AddCorner(Location& loc, bool isClockwise)
   {
     if (isClockwise)
     {
@@ -368,7 +368,7 @@ namespace Clipper2Lib {
     }
   }
 
-  void RectClip64::GetNextLocation(const Path64& path,
+  void RectClipI::GetNextLocation(const PathI& path,
     Location& loc, int& i, int highI)
   {
     switch (loc)
@@ -423,7 +423,7 @@ namespace Clipper2Lib {
     } //switch
   }
 
-  void RectClip64::ExecuteInternal(const Path64& path)
+  void RectClipI::ExecuteInternal(const PathI& path)
   {
     int i = 0, highI = static_cast<int>(path.size()) - 1;
     Location prev = Location::Inside, loc;
@@ -453,8 +453,8 @@ namespace Clipper2Lib {
       GetNextLocation(path, loc, i, highI);
 
       if (i > highI) break;
-      Point64 ip, ip2;
-      Point64 prev_pt = (i) ?
+      PointI ip, ip2;
+      PointI prev_pt = (i) ?
         path[static_cast<size_t>(i - 1)] :
         path[highI];
 
@@ -580,7 +580,7 @@ namespace Clipper2Lib {
     }
   }
 
-  void RectClip64::CheckEdges()
+  void RectClipI::CheckEdges()
   {
     for (size_t i = 0; i < results_.size(); ++i)
     {
@@ -639,7 +639,7 @@ namespace Clipper2Lib {
     }
   }
 
-  void RectClip64::TidyEdges(int idx, OutPt2List& cw, OutPt2List& ccw)
+  void RectClipI::TidyEdges(int idx, OutPt2List& cw, OutPt2List& ccw)
   {
     if (ccw.empty()) return;
     bool isHorz = ((idx == 1) || (idx == 3));
@@ -817,9 +817,9 @@ namespace Clipper2Lib {
     }
   }
 
-  Path64 RectClip64::GetPath(OutPt2*& op)
+  PathI RectClipI::GetPath(OutPt2*& op)
   {
-    if (!op || op->next == op->prev) return Path64();
+    if (!op || op->next == op->prev) return PathI();
 
     OutPt2* op2 = op->next;
     while (op2 && op2 != op)
@@ -834,9 +834,9 @@ namespace Clipper2Lib {
         op2 = op2->next;
     }
     op = op2; // needed for op cleanup
-    if (!op2) return Path64();
+    if (!op2) return PathI();
 
-    Path64 result;
+    PathI result;
     result.push_back(op->pt);
     op2 = op->next;
     while (op2 != op)
@@ -847,12 +847,12 @@ namespace Clipper2Lib {
     return result;
   }
 
-  Paths64 RectClip64::Execute(const Paths64& paths)
+  PathsI RectClipI::Execute(const PathsI& paths)
   {
-    Paths64 result;
+    PathsI result;
     if (rect_.IsEmpty()) return result;
 
-    for (const Path64& path : paths)
+    for (const PathI& path : paths)
     {
       if (path.size() < 3) continue;
       path_bounds_ = GetBounds(path);
@@ -872,7 +872,7 @@ namespace Clipper2Lib {
 
       for (OutPt2*& op :  results_)
       {
-        Path64 tmp = GetPath(op);
+        PathI tmp = GetPath(op);
         if (!tmp.empty())
           result.emplace_back(tmp);
       }
@@ -887,24 +887,24 @@ namespace Clipper2Lib {
   }
 
   //------------------------------------------------------------------------------
-  // RectClipLines64
+  // RectClipLinesI
   //------------------------------------------------------------------------------
 
-  Paths64 RectClipLines64::Execute(const Paths64& paths)
+  PathsI RectClipLinesI::Execute(const PathsI& paths)
   {
-    Paths64 result;
+    PathsI result;
     if (rect_.IsEmpty()) return result;
 
     for (const auto& path : paths)
     {
-      Rect64 pathrec = GetBounds(path);
+      RectI pathrec = GetBounds(path);
       if (!rect_.Intersects(pathrec)) continue;
 
       ExecuteInternal(path);
 
       for (OutPt2*& op : results_)
       {
-        Path64 tmp = GetPath(op);
+        PathI tmp = GetPath(op);
         if (!tmp.empty())
           result.emplace_back(tmp);
       }
@@ -916,7 +916,7 @@ namespace Clipper2Lib {
     return result;
   }
 
-  void RectClipLines64::ExecuteInternal(const Path64& path)
+  void RectClipLinesI::ExecuteInternal(const PathI& path)
   {
     if (rect_.IsEmpty() || path.size() < 2) return;
 
@@ -948,8 +948,8 @@ namespace Clipper2Lib {
       prev = loc;
       GetNextLocation(path, loc, i, highI);
       if (i > highI) break;
-      Point64 ip, ip2;
-      Point64 prev_pt = path[static_cast<size_t>(i - 1)];
+      PointI ip, ip2;
+      PointI prev_pt = path[static_cast<size_t>(i - 1)];
 
       crossing_loc = loc;
       if (!GetIntersection(rect_as_path_,
@@ -986,9 +986,9 @@ namespace Clipper2Lib {
     ///////////////////////////////////////////////////
   }
 
-  Path64 RectClipLines64::GetPath(OutPt2*& op)
+  PathI RectClipLinesI::GetPath(OutPt2*& op)
   {
-    Path64 result;
+    PathI result;
     if (!op || op == op->next) return result;
     op = op->next; // starting at path beginning
     result.push_back(op->pt);

--- a/CPP/Examples/Benchmarks/Benchmarks.cpp
+++ b/CPP/Examples/Benchmarks/Benchmarks.cpp
@@ -15,7 +15,7 @@ const int display_width = 800, display_height = 600;
 void RecheckLastBenchmark(bool use_polytree);
 void DoBenchmark(int edge_cnt_start, int edge_cnt_end, 
   int increment, bool test_polytree = false);
-Path64 MakeRandomPoly(int width, int height, unsigned vertCnt);
+PathI MakeRandomPoly(int width, int height, unsigned vertCnt);
 void System(const std::string &filename);
 
 int main()
@@ -39,9 +39,9 @@ void RecheckLastBenchmark(bool use_polytree)
   ClipType ct;
   FillRule fr;
 
-  Paths64 subject, subj_open, clip, solution;
-  int64_t area, count;
-  PolyTree64 polytree;
+  PathsI subject, subj_open, clip, solution;
+  Integer area, count;
+  PolyTreeI polytree;
 
   std::ifstream test("benchmark_test.txt");
   if (!test.good())
@@ -69,12 +69,12 @@ void RecheckLastBenchmark(bool use_polytree)
     std::cout << "It failed (again)." << std::endl;
 }
 
-inline Path64 MakeRandomPoly(int width, int height, unsigned vertCnt)
+inline PathI MakeRandomPoly(int width, int height, unsigned vertCnt)
 {
-  Path64 result;
+  PathI result;
   result.reserve(vertCnt);
   for (unsigned i = 0; i < vertCnt; ++i)
-    result.push_back(Point64(rand() % width, rand() % height));
+    result.push_back(PointI(rand() % width, rand() % height));
   return result;
 }
 
@@ -84,8 +84,9 @@ void DoBenchmark(int edge_cnt_start, int edge_cnt_end,
   ClipType ct = ClipType::Intersection;
   FillRule fr = FillRule::NonZero;//EvenOdd;//Positive;//
 
-  Paths64 subject, clip, solution;
-  PolyTree64 polytree;
+  Timer tAll;
+  PathsI subject, clip, solution;
+  PolyTreeI polytree;
   std::cout << std::endl << "Complex Polygons Benchmark:  " << std::endl;
   for (int i = edge_cnt_start; i <= edge_cnt_end; i += increment)
   {
@@ -102,18 +103,21 @@ void DoBenchmark(int edge_cnt_start, int edge_cnt_end,
         polytree.Clear();
         Timer t;
         BooleanOp(ct, fr, subject, clip, polytree);
+        std::cout << t.elapsed_str() << std::endl;
         if (!polytree.Count()) break;
       }
       else
       {
         Timer t;
         solution = BooleanOp(ct, fr, subject, clip);
+        std::cout << t.elapsed_str() << std::endl;
         if (solution.empty()) break;
       }
     }
   }
 
-  if (test_polytree) solution = PolyTreeToPaths64(polytree);
+  if (test_polytree) solution = PolyTreeToPathsI(polytree);
+  std::cout << tAll.elapsed_str() << std::endl;
     
   SvgWriter svg;
   SvgAddSubject(svg, subject, fr);

--- a/CPP/Examples/Inflate/Inflate.cpp
+++ b/CPP/Examples/Inflate/Inflate.cpp
@@ -22,39 +22,39 @@ int main(int argc, char* argv[])
 
 void DoSimpleShapes() 
 {
-  Paths64 op1, op2;
+  PathsI op1, op2;
   FillRule fr2 = FillRule::EvenOdd;
   SvgWriter svg2;
 
   op1.push_back(MakePath({ 80,60, 20,20, 180,20, 180,70, 25,150, 20,180, 180,180 }));
   op2 = InflatePaths(op1, 15, JoinType::Miter, EndType::Square, 3);
   SvgAddOpenSubject(svg2, op1, fr2, false);
-  SvgAddSolution(svg2, TransformPaths<double, int64_t>(op2), fr2, false);
+  SvgAddSolution(svg2, TransformPaths<Scalar, Integer>(op2), fr2, false);
   SvgAddCaption(svg2, "Miter Joins; Square Ends", 20, 210);
 
-  op1 = TranslatePaths<int64_t>(op1, 210, 0);
+  op1 = TranslatePaths<Integer>(op1, 210, 0);
   op2 = InflatePaths(op1, 15, JoinType::Square, EndType::Square);
   SvgAddOpenSubject(svg2, op1, fr2, false);
-  SvgAddSolution(svg2, TransformPaths<double, int64_t>(op2), fr2, false);
+  SvgAddSolution(svg2, TransformPaths<Scalar, Integer>(op2), fr2, false);
   SvgAddCaption(svg2, "Square Joins; Square Ends", 230, 210);
 
-  op1 = TranslatePaths<int64_t>(op1, 210, 0);
+  op1 = TranslatePaths<Integer>(op1, 210, 0);
   op2 = InflatePaths(op1, 15, JoinType::Bevel, EndType::Butt, 3);
   SvgAddOpenSubject(svg2, op1, fr2, false);
-  SvgAddSolution(svg2, TransformPaths<double, int64_t>(op2), fr2, false);
+  SvgAddSolution(svg2, TransformPaths<Scalar, Integer>(op2), fr2, false);
   SvgAddCaption(svg2, "Bevel Joins; Butt Ends", 440, 210);
 
-  op1 = TranslatePaths<int64_t>(op1, 210, 0);
+  op1 = TranslatePaths<Integer>(op1, 210, 0);
   op2 = InflatePaths(op1, 15, JoinType::Round, EndType::Round);
   SvgAddOpenSubject(svg2, op1, fr2, false);
-  SvgAddSolution(svg2, TransformPaths<double, int64_t>(op2), fr2, false);
+  SvgAddSolution(svg2, TransformPaths<Scalar, Integer>(op2), fr2, false);
   SvgAddCaption(svg2, "Round Joins; Round Ends", 650, 210);
 
   SvgSaveToFile(svg2, "open_paths.svg", 800, 600, 20);
   System("open_paths.svg");
 
   //triangle offset - with large miter
-  Paths64 p, pp;
+  PathsI p, pp;
   p.push_back(MakePath({ 30, 150, 60, 350, 0, 350 }));
   pp.insert(pp.end(), p.begin(), p.end());
 
@@ -74,7 +74,7 @@ void DoSimpleShapes()
   //different join types within the same offset operation
   ClipperOffset co;
   co.AddPaths(p, JoinType::Miter, EndType::Joined);
-  p = TranslatePaths<int64_t>(p, 120, 100);
+  p = TranslatePaths<Integer>(p, 120, 100);
   pp.insert(pp.end(), p.begin(), p.end());
   co.AddPaths(p, JoinType::Round, EndType::Joined);
   co.Execute(10, p);
@@ -82,7 +82,7 @@ void DoSimpleShapes()
 
   FillRule fr3 = FillRule::EvenOdd;
   SvgWriter svg;
-  SvgAddSolution(svg, TransformPaths<double, int64_t>(pp), fr3, false);
+  SvgAddSolution(svg, TransformPaths<Scalar, Integer>(pp), fr3, false);
   SvgSaveToFile(svg, "solution_off.svg", 800, 600, 20);
   System("solution_off.svg");
 }
@@ -91,10 +91,10 @@ void DoRabbit()
 {
   SvgReader svg_reader;
   svg_reader.LoadFromFile("./rabbit.svg");
-  PathsD p = svg_reader.GetPaths();
+  PathsS p = svg_reader.GetPaths();
 
   JoinType jt = JoinType::Round;
-  PathsD solution(p);
+  PathsS solution(p);
 
   while (p.size())
   {

--- a/CPP/Examples/MemLeakTest/MemLeakTest.cpp
+++ b/CPP/Examples/MemLeakTest/MemLeakTest.cpp
@@ -9,7 +9,7 @@ using namespace Clipper2Lib;
 const int display_width = 800, display_height = 600;
 
 void DoMemoryLeakTest();
-Path64 MakeRandomPoly(int width, int height, unsigned vertCnt);
+PathI MakeRandomPoly(int width, int height, unsigned vertCnt);
 void System(const std::string &filename);
 
 int main()
@@ -28,12 +28,12 @@ int main()
 }
 
 
-inline Path64 MakeRandomPoly(int width, int height, unsigned vertCnt)
+inline PathI MakeRandomPoly(int width, int height, unsigned vertCnt)
 {
-  Path64 result;
+  PathI result;
   result.reserve(vertCnt);
   for (unsigned i = 0; i < vertCnt; ++i)
-    result.push_back(Point64(rand() % width, rand() % height));
+    result.push_back(PointI(rand() % width, rand() % height));
   return result;
 }
 
@@ -42,14 +42,14 @@ void DoMemoryLeakTest()
 #ifdef _WIN32
   int edge_cnt = 1000;
 
-  Paths64 subject, clip;
+  PathsI subject, clip;
   subject.push_back(MakeRandomPoly(800, 600, edge_cnt));
   clip.push_back(MakeRandomPoly(800, 600, edge_cnt));
 
   _CrtMemState sOld {}, sNew {}, sDiff {};
   _CrtMemCheckpoint(&sOld); //take a snapshot
   {
-    Paths64 solution = Intersect(subject, clip, FillRule::NonZero);
+    PathsI solution = Intersect(subject, clip, FillRule::NonZero);
   }
   _CrtMemCheckpoint(&sNew); //take another snapshot (outside code block)
   if (_CrtMemDifference(&sDiff, &sOld, &sNew)) // check for a difference

--- a/CPP/Examples/PolygonSamples/PolygonSamples.cpp
+++ b/CPP/Examples/PolygonSamples/PolygonSamples.cpp
@@ -29,8 +29,8 @@ int main()
 
 void DoLoopThruPolygons(int start, int end)
 {
-  Paths64 subject, subject_open, clip, solution, solution_open;
-  int64_t stored_area, stored_count;
+  PathsI subject, subject_open, clip, solution, solution_open;
+  Integer stored_area, stored_count;
   ClipType ct;
   FillRule fr;
   bool first_fail = true;
@@ -43,7 +43,7 @@ void DoLoopThruPolygons(int start, int end)
   {
     if (!LoadTestNum(ifs, test_number,
       subject, subject_open, clip, stored_area, stored_count, ct, fr)) break;
-    Clipper64 c64;
+    ClipperI c64;
     c64.AddSubject(subject);
     c64.AddOpenSubject(subject_open);
     c64.AddClip(clip);
@@ -51,14 +51,14 @@ void DoLoopThruPolygons(int start, int end)
 
     if (do_all)
     {
-      double area = (double)Area(solution);
-      double area_diff = (double)stored_area <= 0 ?
+      Scalar area = (Scalar)Area(solution);
+      Scalar area_diff = (Scalar)stored_area <= 0 ?
         0 :
-        std::fabs((area / (double)stored_area) - 1.0);
+        std::fabs((area / (Scalar)stored_area) - 1.0);
       int count = (int)(solution.size());
-      double count_diff = stored_count <= 0 ? 
+      Scalar count_diff = stored_count <= 0 ? 
         0 : 
-        std::abs(count - stored_count)/(double)stored_count;
+        std::abs(count - stored_count)/(Scalar)stored_count;
       if (count_diff > 0.02 || (area_diff > 0.1))
       {
         if (first_fail)

--- a/CPP/Examples/RandomClipping/RandomClipping.cpp
+++ b/CPP/Examples/RandomClipping/RandomClipping.cpp
@@ -30,19 +30,19 @@ int GenerateRandomNumber(std::default_random_engine& rng, int min_value, int max
   return distribution(rng);
 }
 
-Paths64 GenerateRandomPaths(std::default_random_engine& rng,  int path_count, int edge_count)
+PathsI GenerateRandomPaths(std::default_random_engine& rng,  int path_count, int edge_count)
 {
-  if (!path_count) return Paths64();
+  if (!path_count) return PathsI();
   // with fewer paths, keep them closer to the center of the display ...
-  double center_x = display_width / 2.0; 
-  double center_y = display_height / 2.0;
-  double dx = center_x / 3.0 * (static_cast<double>(path_count) / max_paths);
-  double dy = center_y / 3.0 * (static_cast<double>(path_count) / max_paths);
-  std::normal_distribution<double> first_point_coordinate_x(0, dx);
-  std::normal_distribution<double> first_point_coordinate_y(0, dy);
+  Scalar center_x = display_width / 2.0; 
+  Scalar center_y = display_height / 2.0;
+  Scalar dx = center_x / 3.0 * (static_cast<Scalar>(path_count) / max_paths);
+  Scalar dy = center_y / 3.0 * (static_cast<Scalar>(path_count) / max_paths);
+  std::normal_distribution<Scalar> first_point_coordinate_x(0, dx);
+  std::normal_distribution<Scalar> first_point_coordinate_y(0, dy);
   std::uniform_int_distribution<int> orthogonal_dist_next_point(-100, 100);
 
-  Clipper2Lib::Paths64 result(path_count);
+  Clipper2Lib::PathsI result(path_count);
 
   for (int path = 0; path < path_count; ++path)
   {
@@ -102,7 +102,7 @@ void RandomTest(int path_count)
   int max_edges = path_count * 3;
   path_count = std::min(max_paths, path_count);
 
-  Paths64 subj, subj_open, clip, sol, sol_open;
+  PathsI subj, subj_open, clip, sol, sol_open;
   // generate exactly path_count subjects, between 0 & path_count open subjects, 
   // and between 1 & path_count clips 
   subj = GenerateRandomPaths(rng, path_count, GenerateRandomNumber(rng, 3, max_edges));
@@ -112,11 +112,11 @@ void RandomTest(int path_count)
     GenerateRandomNumber(rng, 1, path_count), GenerateRandomNumber(rng, 3, max_edges));
 
   //SaveTest("random.txt", false, &subj, &subj_open, &clip, 0, 0, cliptype, fillrule);
-  //int64_t area, cnt;
+  //Integer area, cnt;
   //std::ifstream ifs("random2.txt");
   //LoadTestNum(ifs, 1, subj, subj_open, clip, area, cnt, cliptype, fillrule);
 
-  Clipper64 c64;
+  ClipperI c64;
   c64.AddSubject(subj);
   c64.AddOpenSubject(subj_open);
   c64.AddClip(clip);

--- a/CPP/Examples/RectClipping/RectClipping.cpp
+++ b/CPP/Examples/RectClipping/RectClipping.cpp
@@ -37,21 +37,21 @@ int main(int argc, char* argv[])
   PressEnterToExit();
 }
 
-Path64 MakeRandomEllipse(int minWidth, int minHeight, int maxWidth, int maxHeight,
+PathI MakeRandomEllipse(int minWidth, int minHeight, int maxWidth, int maxHeight,
   int maxRight, int maxBottom)
 {
   int w = maxWidth > minWidth ? minWidth + rand() % (maxWidth - minWidth) : minWidth;
   int h = maxHeight > minHeight ? minHeight + rand() % (maxHeight - minHeight) : minHeight;
   int l = rand() % (maxRight - w);
   int t = rand() % (maxBottom - h);
-  return Ellipse(Rect64(l, t, l + w, t + h));
+  return Ellipse(RectI(l, t, l + w, t + h));
 }
 
 void DoEllipses(int cnt)
 {
-  Paths64 sub, clp, sol, store;
+  PathsI sub, clp, sol, store;
 
-  Rect64 rect = Rect64(margin, margin, width - margin, height - margin);
+  RectI rect = RectI(margin, margin, width - margin, height - margin);
   clp.push_back(rect.AsPath());
   for (int i = 0; i < cnt; ++i)
     sub.push_back(MakeRandomEllipse(10, 10, 100, 100, width, height));
@@ -69,26 +69,26 @@ void DoEllipses(int cnt)
   System("rectclip1.svg");
 }
 
-Path64 MakeRandomRectangle(int minWidth, int minHeight, int maxWidth, int maxHeight,
+PathI MakeRandomRectangle(int minWidth, int minHeight, int maxWidth, int maxHeight,
   int maxRight, int maxBottom)
 {
   int w = maxWidth > minWidth ? minWidth + rand() % (maxWidth - minWidth): minWidth;
   int h = maxHeight > minHeight ? minHeight + rand() % (maxHeight - minHeight): minHeight;
   int l = rand() % (maxRight - w);
   int t = rand() % (maxBottom - h);
-  Path64 result;
+  PathI result;
   result.reserve(4);
-  result.push_back(Point64(l, t));
-  result.push_back(Point64(l+w, t));
-  result.push_back(Point64(l+w, t+h));
-  result.push_back(Point64(l, t+h));
+  result.push_back(PointI(l, t));
+  result.push_back(PointI(l+w, t));
+  result.push_back(PointI(l+w, t+h));
+  result.push_back(PointI(l, t+h));
   return result;
 }
 
 void DoRectangles(int cnt)
 {
-  Paths64 sub, clp, sol, store;
-  Rect64 rect = Rect64(margin, margin, width - margin, height - margin);
+  PathsI sub, clp, sol, store;
+  RectI rect = RectI(margin, margin, width - margin, height - margin);
   clp.push_back(rect.AsPath());
   for (int i = 0; i < cnt; ++i)
     sub.push_back(MakeRandomRectangle(10, 10, 100, 100, width, height));
@@ -104,30 +104,30 @@ void DoRectangles(int cnt)
   System("rectclip2.svg");
 }
 
-Path64 MakeRandomPoly(int width, int height, unsigned vertCnt)
+PathI MakeRandomPoly(int width, int height, unsigned vertCnt)
 {
-  Path64 result;
+  PathI result;
   result.reserve(vertCnt);
   for (unsigned i = 0; i < vertCnt; ++i)
-    result.push_back(Point64(rand() % width, rand() % height));
+    result.push_back(PointI(rand() % width, rand() % height));
   return result;
 }
 
-PathD MakeRandomPolyD(int width, int height, unsigned vertCnt)
+PathS MakeRandomPolyD(int width, int height, unsigned vertCnt)
 {
-  PathD result;
+  PathS result;
   result.reserve(vertCnt);
   for (unsigned i = 0; i < vertCnt; ++i)
-    result.push_back(PointD(rand() % width, rand() % height));
+    result.push_back(PointS(rand() % width, rand() % height));
   return result;
 }
 
 void DoRandomPoly(int count)
 {
-  PathsD sub, clp, sol;
+  PathsS sub, clp, sol;
 
   // generate random poly
-  RectD rect = RectD(margin, margin, width - margin, height - margin);
+  RectS rect = RectS(margin, margin, width - margin, height - margin);
   clp.push_back(rect.AsPath());
   sub.push_back(MakeRandomPolyD(width, height, count));
 
@@ -136,13 +136,13 @@ void DoRandomPoly(int count)
   //////////////////////////////////
 
   FillRule fr = FillRule::EvenOdd;
-  double frac = sol.size() ? 1.0 / sol.size() : 1.0;
-  double cum_frac = 0;
+  Scalar frac = sol.size() ? 1.0 / sol.size() : 1.0;
+  Scalar cum_frac = 0;
   SvgWriter svg;
   svg.AddPaths(sub, false, fr, 0x100066FF, 0x800066FF, 1, false);
   svg.AddPaths(clp, false, fr, 0x10FFAA00, 0x80FF0000, 1, false);
   //svg.AddPaths(sol, false, fr, 0x30AAFF00, 0xFF00FF00, 1, false);
-  for (const PathD& sol_path : sol)
+  for (const PathS& sol_path : sol)
   {
     uint32_t c = RainbowColor(cum_frac, 64);
     cum_frac += frac;
@@ -156,8 +156,8 @@ void DoRandomPoly(int count)
 void MeasurePerformance(int min, int max, int step)
 {
   FillRule fr = FillRule::EvenOdd;
-  Paths64 sub, clp, sol, store;
-  Rect64 rect = Rect64(margin, margin, width - margin, height - margin);
+  PathsI sub, clp, sol, store;
+  RectI rect = RectI(margin, margin, width - margin, height - margin);
   clp.push_back(rect.AsPath());
 
   for (int cnt = min; cnt <= max; cnt += step)
@@ -167,7 +167,7 @@ void MeasurePerformance(int min, int max, int step)
 
     std::cout << std::endl << cnt << " random poly" << std::endl;
     {
-      Timer t("Clipper64: ");
+      Timer t("ClipperI: ");
       sol = Intersect(sub, clp, fr);
     }
 
@@ -182,9 +182,9 @@ void MeasurePerformance(int min, int max, int step)
   svg.AddPaths(sub, false, fr, 0x200066FF, 0x400066FF, 1, false);
   svg.AddPaths(clp, false, fr, 0x10FFAA00, 0xFFFF0000, 1, false);
   //svg.AddPaths(sol, false, fr, 0x8066FF66, 0xFF006600, 1, false);
-  double frac = sol.size() ? 1.0 / sol.size() : 1.0;
-  double cum_frac = 0;
-  for (const Path64& sol_path : sol)
+  Scalar frac = sol.size() ? 1.0 / sol.size() : 1.0;
+  Scalar cum_frac = 0;
+  for (const PathI& sol_path : sol)
   {
     uint32_t c = RainbowColor(cum_frac, 64);
     cum_frac += frac;

--- a/CPP/Examples/SimpleClipping/SimpleClipping.cpp
+++ b/CPP/Examples/SimpleClipping/SimpleClipping.cpp
@@ -7,7 +7,7 @@
 using namespace Clipper2Lib;
 
 void DoSimpleTest(bool show_solution_coords = false);
-Path64 MakeRandomPoly(int width, int height, unsigned vertCnt);
+PathI MakeRandomPoly(int width, int height, unsigned vertCnt);
 void System(const std::string &filename);
 
 int main()
@@ -15,12 +15,12 @@ int main()
   DoSimpleTest();    
 }
 
-inline Path64 MakeStar(const Point64& center, int radius, int points)
+inline PathI MakeStar(const PointI& center, int radius, int points)
 {
   if (!(points % 2)) --points;
   if (points < 5) points = 5;
-  Path64 tmp = Ellipse<int64_t>(center, radius, radius, points);
-  Path64 result;
+  PathI tmp = Ellipse<Integer>(center, radius, radius, points);
+  PathI result;
   result.reserve(points);
   result.push_back(tmp[0]);
   for (int i = points - 1, j = i / 2; j;)
@@ -34,12 +34,12 @@ inline Path64 MakeStar(const Point64& center, int radius, int points)
 
 void DoSimpleTest(bool show_solution_coords)
 {
-  Paths64 tmp, solution;
+  PathsI tmp, solution;
   FillRule fr = FillRule::NonZero;
 
-  Paths64 subject, clip;
-  subject.push_back(MakeStar(Point64(225, 225), 220, 9));
-  clip.push_back(Ellipse<int64_t>(Point64(225,225), 150, 150));  
+  PathsI subject, clip;
+  subject.push_back(MakeStar(PointI(225, 225), 220, 9));
+  clip.push_back(Ellipse<Integer>(PointI(225,225), 150, 150));  
   
   //Intersect both shapes and then 'inflate' result -10 (ie deflate)
   solution = Intersect(subject, clip, fr);

--- a/CPP/Examples/UnionClipping/UnionClipping.cpp
+++ b/CPP/Examples/UnionClipping/UnionClipping.cpp
@@ -46,13 +46,13 @@ void DoDiamonds()
 {
   static const int size = 10, size2 = size * 2;;
   static const int w = 800, h = 600;
-  Path64 shape;
-  shape.push_back(Point64(size, 0));
-  shape.push_back(Point64(size2, size));
-  shape.push_back(Point64(size, size2));
-  shape.push_back(Point64(0, size));
+  PathI shape;
+  shape.push_back(PointI(size, 0));
+  shape.push_back(PointI(size2, size));
+  shape.push_back(PointI(size, size2));
+  shape.push_back(PointI(0, size));
 
-  Paths64 subjects, solution;
+  PathsI subjects, solution;
   
   for (int i = 0; i < h / size; i += 2)
   {
@@ -61,7 +61,7 @@ void DoDiamonds()
       shape = TranslatePath(shape, size, (j & 1) == 0 ? size : -size);
       if (rand() % 7) subjects.push_back(shape);
     }
-    shape = TranslatePath(shape, static_cast<int64_t>(-w / size) * size, size*2);
+    shape = TranslatePath(shape, static_cast<Integer>(-w / size) * size, size*2);
   }
 
   solution = Union(subjects, FillRule::NonZero);
@@ -77,12 +77,12 @@ void DoSquares()
 {
   static const int w = 800, h = 600;
   static const int size = 10;
-  Path64 shape;
-  shape.push_back(Point64(0, 0));
-  shape.push_back(Point64(size, 0));
-  shape.push_back(Point64(size, size));
-  shape.push_back(Point64(0, size));
-  Paths64 subjects, solution;
+  PathI shape;
+  shape.push_back(PointI(0, 0));
+  shape.push_back(PointI(size, 0));
+  shape.push_back(PointI(size, size));
+  shape.push_back(PointI(0, size));
+  PathsI subjects, solution;
   ClipType cliptype = ClipType::Union;
   FillRule fillrule = FillRule::NonZero;
 
@@ -93,7 +93,7 @@ void DoSquares()
       if (rand() % 4 != 1) subjects.push_back(shape);
       shape = TranslatePath(shape, size, 0);
     }
-    shape = TranslatePath(shape, static_cast<int64_t>(-w / size) * size, size);
+    shape = TranslatePath(shape, static_cast<Integer>(-w / size) * size, size);
   }
   //SaveTest("squares.txt", false, &subjects, nullptr, nullptr, 0, 0, ClipType::Union, FillRule::NonZero);
 
@@ -109,9 +109,9 @@ void DoSquares()
 void DoCircles()
 {
   // create a small circle with 31 vertices
-  PathD shape = Ellipse(RectD(0, 0, 35, 35), 31);
+  PathS shape = Ellipse(RectS(0, 0, 35, 35), 31);
 
-  PathsD subjects, solution;
+  PathsS subjects, solution;
   int w = 800, h = 600;
 
   for (int j = 0; j < 550; ++j)
@@ -132,16 +132,16 @@ void DoTriangles()
 {
   static const int w = 800, h = 600;
   static const int size = 10;
-  Path64 tri1;
-  tri1.push_back(Point64(0, 0));
-  tri1.push_back(Point64(size * 2, 0));
-  tri1.push_back(Point64(size, size * 2));
-  Path64 tri2;
-  tri2.push_back(Point64(size * 2, 0));
-  tri2.push_back(Point64(size, size * 2));
-  tri2.push_back(Point64(size * 3, size * 2));
+  PathI tri1;
+  tri1.push_back(PointI(0, 0));
+  tri1.push_back(PointI(size * 2, 0));
+  tri1.push_back(PointI(size, size * 2));
+  PathI tri2;
+  tri2.push_back(PointI(size * 2, 0));
+  tri2.push_back(PointI(size, size * 2));
+  tri2.push_back(PointI(size * 3, size * 2));
 
-  Paths64 subjects, solution;
+  PathsI subjects, solution;
   ClipType cliptype = ClipType::Union;
   FillRule fillrule = FillRule::NonZero;
 
@@ -154,8 +154,8 @@ void DoTriangles()
       tri1 = TranslatePath(tri1, size * 2, 0);
       tri2 = TranslatePath(tri2, size * 2, 0);
     }
-    tri1 = TranslatePath(tri1, static_cast<int64_t>(-w / size) * size, size * 2);
-    tri2 = TranslatePath(tri2, static_cast<int64_t>(-w / size) * size, size * 2);
+    tri1 = TranslatePath(tri1, static_cast<Integer>(-w / size) * size, size * 2);
+    tri2 = TranslatePath(tri2, static_cast<Integer>(-w / size) * size, size * 2);
   }
 
   solution = Union(subjects, fillrule);

--- a/CPP/Examples/UsingZ/UsingZ.cpp
+++ b/CPP/Examples/UsingZ/UsingZ.cpp
@@ -10,23 +10,23 @@ using namespace Clipper2Lib;
 
 void System(const std::string &filename);
 void TestingZ_Int64();
-void TestingZ_Double();
+void TestingZ_Scalar();
 
 // use the Z callback to flag intersections by setting z = 1;
 
 class MyClass {
 public:
   
-  // Point64 callback - see TestingZ_Int64()
-  void myZCB(const Point64& e1bot, const Point64& e1top,
-    const Point64& e2bot, const Point64& e2top, Point64& pt)
+  // PointI callback - see TestingZ_Int64()
+  void myZCB(const PointI& e1bot, const PointI& e1top,
+    const PointI& e2bot, const PointI& e2top, PointI& pt)
   {
     pt.z = 1;
   }
 
-  // PointD callback - see TestingZ_Double()
-  void myZCBD(const PointD& e1bot, const PointD& e1top,
-    const PointD& e2bot, const PointD& e2top, PointD& pt)
+  // PointS callback - see TestingZ_Scalar()
+  void myZCBD(const PointS& e1bot, const PointS& e1top,
+    const PointS& e2bot, const PointS& e2top, PointS& pt)
   {
     pt.z = 1;
   }
@@ -35,15 +35,15 @@ public:
 int main(int argc, char* argv[])
 {
   //TestingZ_Int64();
-  TestingZ_Double();
+  TestingZ_Scalar();
 }
 
 void TestingZ_Int64()
 {
 
-  Paths64 subject, solution;
+  PathsI subject, solution;
   MyClass mc;
-  Clipper64 c64;
+  ClipperI c64;
 
   subject.push_back(MakePath({ 100, 50, 10, 79, 65, 2, 65, 98, 10, 21 }));
   c64.AddSubject(subject);
@@ -57,12 +57,12 @@ void TestingZ_Int64()
   SvgAddSolution(svg, solution, FillRule::NonZero, false);
   if (solution.size() > 0) {
     // draw circles around intersection points - flagged by z == 1
-    PathsD ellipses;
-    double r = 3.0;
-    for (const Point64& pt : solution[0])
+    PathsS ellipses;
+    Scalar r = 3.0;
+    for (const PointI& pt : solution[0])
       if (pt.z == 1)
       {
-        ellipses.push_back(Ellipse(RectD(pt.x - r, pt.y - r, pt.x + r, pt.y + r), 11));
+        ellipses.push_back(Ellipse(RectS(pt.x - r, pt.y - r, pt.x + r, pt.y + r), 11));
       }
     SvgAddClip(svg, ellipses, FillRule::NonZero);
   }
@@ -70,13 +70,13 @@ void TestingZ_Int64()
   System("usingz_int64.svg");
 }
 
-void TestingZ_Double()
+void TestingZ_Scalar()
 {
-  PathsD subject, solution;
+  PathsS subject, solution;
   MyClass mc;
-  ClipperD c;
+  ClipperS c;
 
-  subject.push_back(MakePathD({ 100, 50, 10, 79, 65, 2, 65, 98, 10, 21 }));
+  subject.push_back(MakePathS({ 100, 50, 10, 79, 65, 2, 65, 98, 10, 21 }));
   c.AddSubject(subject);
   c.SetZCallback(
     std::bind(&MyClass::myZCBD, mc, std::placeholders::_1,
@@ -89,17 +89,17 @@ void TestingZ_Double()
   if (solution.size() > 0) 
   {
     // draw circles around intersection points
-    PathsD ellipses;
-    double r = 3.0;
-    for (const PointD& pt : solution[0])
+    PathsS ellipses;
+    Scalar r = 3.0;
+    for (const PointS& pt : solution[0])
       if (pt.z == 1)
-        ellipses.push_back(Ellipse(RectD(pt.x - r, pt.y - r, 
+        ellipses.push_back(Ellipse(RectS(pt.x - r, pt.y - r, 
           pt.x + r, pt.y + r), 11));
 
     SvgAddSolution(svg, ellipses, FillRule::NonZero, false);
   }
-  SvgSaveToFile(svg, "usingz_double.svg", 320, 320, 0);
-  System("usingz_double.svg");
+  SvgSaveToFile(svg, "usingz_Scalar.svg", 320, 320, 0);
+  System("usingz_Scalar.svg");
 }
 
 void System(const std::string &filename)

--- a/CPP/Examples/VariableOffset/VariableOffset.cpp
+++ b/CPP/Examples/VariableOffset/VariableOffset.cpp
@@ -18,23 +18,23 @@ void System(const std::string& filename)
 
 void test1() {
 
-  int64_t const scale = 10;
-  double delta = 10 * scale;
+  Integer const scale = 10;
+  Scalar delta = 10 * scale;
 
   ClipperOffset co;
-  co.SetDeltaCallback([delta](const Path64& path,
-    const PathD& path_norms, size_t curr_idx, size_t prev_idx)
+  co.SetDeltaCallback([delta](const PathI& path,
+    const PathS& path_norms, size_t curr_idx, size_t prev_idx)
     {
       // gradually scale down the offset to a minimum of 25% of delta
-      double high = static_cast<double>(path.size() - 1) * 1.25;
+      Scalar high = static_cast<Scalar>(path.size() - 1) * 1.25;
       return (high - curr_idx) / high * delta;
     });
 
-  Paths64 subject{ Ellipse(Rect64(0, 0, 200 * scale, 180 * scale)) };
+  PathsI subject{ Ellipse(RectI(0, 0, 200 * scale, 180 * scale)) };
   subject[0].resize(subject[0].size() * 0.9);
 
   co.AddPaths(subject, JoinType::Miter, EndType::Round);
-  Paths64 solution;
+  PathsI solution;
   co.Execute(1.0, solution);
 
   std::string filename = "test1.svg";
@@ -47,22 +47,22 @@ void test1() {
 
 void test2() {
 
-  int64_t const scale = 10;
-  double delta = 10 * scale;
+  Integer const scale = 10;
+  Scalar delta = 10 * scale;
 
   ClipperOffset co;
-  co.SetDeltaCallback([delta](const Path64& path,
-    const PathD& path_norms, size_t curr_idx, size_t prev_idx) {
+  co.SetDeltaCallback([delta](const PathI& path,
+    const PathS& path_norms, size_t curr_idx, size_t prev_idx) {
       // calculate offset based on distance from the middle of the path
-      double mid_idx = static_cast<double>(path.size()) / 2.0;
-      return delta * (1.0 - 0.70 * (std::fabs(curr_idx - mid_idx) / mid_idx));
+      Scalar mid_idx = static_cast<Scalar>(path.size()) / 2.0;
+      return delta * ((Scalar)1.0 - (Scalar)0.70 * (std::fabs(curr_idx - mid_idx) / mid_idx));
     });
 
-  Paths64 subject{ Ellipse(Rect64(0, 0, 200 * scale, 180 * scale)) };
+  PathsI subject{ Ellipse(RectI(0, 0, 200 * scale, 180 * scale)) };
   subject[0].resize(subject[0].size() * 0.9);
 
   co.AddPaths(subject, JoinType::Miter, EndType::Round);
-  Paths64 solution;
+  PathsI solution;
   co.Execute(1.0, solution);
 
   std::string filename = "test2.svg";
@@ -75,22 +75,22 @@ void test2() {
 
 void test3() {
 
-  double radius = 5000.0;
-  Paths64 subject = { Ellipse(Rect64(-radius, -radius, radius, radius), 200) };
+  Scalar radius = (Scalar)5000.0;
+  PathsI subject = { Ellipse(RectI(-radius, -radius, radius, radius), 200) };
 
   ClipperOffset co;
   co.AddPaths(subject, JoinType::Miter, EndType::Polygon);
 
-  co.SetDeltaCallback([radius](const Path64& path,
-    const PathD& path_norms, size_t curr_idx, size_t prev_idx) {
+  co.SetDeltaCallback([radius](const PathI& path,
+    const PathS& path_norms, size_t curr_idx, size_t prev_idx) {
       // when multiplying the x & y of edge unit normal vectors, the value will be 
       // largest (0.5) when edges are at 45 deg. and least (-0.5) at negative 45 deg.
-      double delta = path_norms[curr_idx].y * path_norms[curr_idx].x;
-      return radius * 0.5 + radius * delta;
+      Scalar delta = path_norms[curr_idx].y * path_norms[curr_idx].x;
+      return radius * ((Scalar)0.5) + radius * delta;
     });
 
   //  solution
-  Paths64 solution;
+  PathsI solution;
   co.Execute(1.0, solution);
 
   std::string filename = "test3.svg";
@@ -103,20 +103,20 @@ void test3() {
 
 void test4() {
 
-  int64_t const scale = 100;
-  Paths64 solution;
-  Paths64 subject = { Ellipse(ScaleRect<int64_t,int64_t>(Rect64(10, 10, 50, 50), scale)) };
+  Integer const scale = 100;
+  PathsI solution;
+  PathsI subject = { Ellipse(ScaleRect<Integer,Integer>(RectI(10, 10, 50, 50), scale)) };
 
   ClipperOffset co;
   co.AddPaths(subject, JoinType::Round, EndType::Round);
   co.Execute(
-    [scale](const Path64& path,
-      const PathD& path_norms, size_t curr_idx, size_t prev_idx) {
-        //double vertex_sin_a = CrossProduct(path_norms[curr_idx], path_norms[prev_idx]);
-        //double vertex_cos_a = DotProduct(path_norms[curr_idx], path_norms[prev_idx]);
-        //double vertex_angle = std::atan2(vertex_sin_a, vertex_cos_a);
-        //double edge_angle = std::atan2(path_norms[curr_idx].y, path_norms[curr_idx].x);
-        double sin_edge = path_norms[curr_idx].y;
+    [scale](const PathI& path,
+      const PathS& path_norms, size_t curr_idx, size_t prev_idx) {
+        //Scalar vertex_sin_a = CrossProduct(path_norms[curr_idx], path_norms[prev_idx]);
+        //Scalar vertex_cos_a = DotProduct(path_norms[curr_idx], path_norms[prev_idx]);
+        //Scalar vertex_angle = std::atan2(vertex_sin_a, vertex_cos_a);
+        //Scalar edge_angle = std::atan2(path_norms[curr_idx].y, path_norms[curr_idx].x);
+        Scalar sin_edge = path_norms[curr_idx].y;
         return Sqr(sin_edge) * 3 * scale; }
   , solution);
 
@@ -130,15 +130,15 @@ void test4() {
 
 void test5() {
 
-  Paths64 solution;
-  Paths64 subject = { MakePath({0,0, 20,0, 40,0, 60,0, 80,0, 100,0}) };
+  PathsI solution;
+  PathsI subject = { MakePath({0,0, 20,0, 40,0, 60,0, 80,0, 100,0}) };
 
   ClipperOffset co;
   co.AddPaths(subject, JoinType::Round, EndType::Butt);
   co.Execute(
-    [](const Path64& path,
-      const PathD& path_norms, size_t curr_idx, size_t prev_idx) {
-        return double(curr_idx * curr_idx + 10); }
+    [](const PathI& path,
+      const PathS& path_norms, size_t curr_idx, size_t prev_idx) {
+        return Scalar(curr_idx * curr_idx + 10); }
   , solution);
 
   SvgWriter svg;

--- a/CPP/Tests/TestExportHeaders.cpp
+++ b/CPP/Tests/TestExportHeaders.cpp
@@ -3,52 +3,52 @@
 #include "clipper2/clipper.core.h"
 #include "clipper2/clipper.export.h"
 using namespace Clipper2Lib;
-static bool CreatePolyPath64FromCPolyPath(CPolyPath64& v, PolyPath64& owner)
+static bool CreatePolyPath64FromCPolyPath(CPolyPathI& v, PolyPathI& owner)
 {
-  int64_t poly_len = *v++, child_count = *v++;
+  Integer poly_len = *v++, child_count = *v++;
   if (!poly_len) return false;
-  Path64 path;
+  PathI path;
   path.reserve(poly_len);
   for (size_t i = 0; i < poly_len; ++i)
   {
-    int64_t x = *v++, y = *v++;
-    path.push_back(Point64(x,y));
+    Integer x = *v++, y = *v++;
+    path.push_back(PointI(x,y));
   }
-  PolyPath64* new_owner = owner.AddChild(path);
+  PolyPathI* new_owner = owner.AddChild(path);
   for (size_t i = 0; i < child_count; ++i)
     CreatePolyPath64FromCPolyPath(v, *new_owner);
   return true;
 }
-static bool BuildPolyTree64FromCPolyTree(CPolyTree64 tree, PolyTree64& result)
+static bool BuildPolyTree64FromCPolyTree(CPolyTreeI tree, PolyTreeI& result)
 {
   result.Clear();
-  int64_t* v = tree;
-  int64_t array_len = *v++, child_count = *v++;
+  Integer* v = tree;
+  Integer array_len = *v++, child_count = *v++;
   for (size_t i = 0; i < child_count; ++i)
     if (!CreatePolyPath64FromCPolyPath(v, result)) return false;
   return true;
 }
-static bool CreatePolyPathDFromCPolyPath(CPolyPathD& v, PolyPathD& owner)
+static bool CreatePolyPathDFromCPolyPath(CPolyPathS& v, PolyPathS& owner)
 {
-  int64_t poly_len = *v++, child_count = *v++;
+  Integer poly_len = *v++, child_count = *v++;
   if (!poly_len) return false;
-  PathD path;
+  PathS path;
   path.reserve(poly_len);
   for (size_t i = 0; i < poly_len; ++i)
   {
-    int64_t x = *v++, y = *v++;
-    path.push_back(PointD(x, y));
+    Integer x = *v++, y = *v++;
+    path.push_back(PointS(x, y));
   }
-  PolyPathD* new_owner = owner.AddChild(path);
+  PolyPathS* new_owner = owner.AddChild(path);
   for (size_t i = 0; i < child_count; ++i)
     CreatePolyPathDFromCPolyPath(v, *new_owner);
   return true;
 }
-static bool BuildPolyTreeDFromCPolyTree(CPolyTreeD tree, PolyTreeD& result)
+static bool BuildPolyTreeDFromCPolyTree(CPolyTreeS tree, PolyTreeD& result)
 {
   result.Clear();
-  double* v = tree;
-  int64_t array_len = *v++, child_count = *v++;
+  Scalar* v = tree;
+  Integer array_len = *v++, child_count = *v++;
   for (size_t i = 0; i < child_count; ++i)
     if (!CreatePolyPathDFromCPolyPath(v, result)) return false;
   return true;
@@ -57,85 +57,85 @@ TEST(Clipper2Tests, ExportHeader64)
 {
   uint8_t None = 0, Intersection = 1, Union = 2, Difference = 3, Xor = 4;
   uint8_t EvenOdd = 0, NonZero = 1, Positive = 2, Negative = 3;
-  Paths64 subj, clip, solution;
+  PathsI subj, clip, solution;
   //subj.push_back(MakeRandomPoly(600, 400, 25));
   //clip.push_back(MakeRandomPoly(600, 400, 25));
   for (int i = 1; i < 6; ++i)
     subj.push_back(MakePath({ -i*20,-i * 20, i * 20,-i * 20, i * 20,i * 20, -i * 20,i * 20 }));
   clip.push_back(MakePath({ -90,-120,90,-120, 90,120, -90,120 }));
-  CPaths64 c_subj_open = nullptr, c_sol = nullptr, c_sol_open = nullptr;
+  CPathsI c_subj_open = nullptr, c_sol = nullptr, c_sol_open = nullptr;
   // Note: while CreateCPaths64 isn't exported in clipper.export.h, it can still
   // be used here because we're simply statically compiling clipper.export.h.
   // Normally clipper.export.h will be compiled into a DLL/so so it can be called
   // by non C++ applications. If CreateCPaths64 was an exported function and it
   // was called by a non C++ application, it would crash that application.
-  CPaths64 c_subj = CreateCPaths(subj);
-  CPaths64 c_clip = CreateCPaths(clip);
-  BooleanOp64(Intersection, EvenOdd, c_subj, c_subj_open, c_clip, c_sol, c_sol_open);
+  CPathsI c_subj = CreateCPaths(subj);
+  CPathsI c_clip = CreateCPaths(clip);
+  BooleanOpI(Intersection, EvenOdd, c_subj, c_subj_open, c_clip, c_sol, c_sol_open);
   solution = ConvertCPaths(c_sol);
   //clean up !!!
   delete[] c_subj;
   delete[] c_clip;
-  DisposeArray64(c_sol);
-  DisposeArray64(c_sol_open);
+  DisposeArrayI(c_sol);
+  DisposeArrayI(c_sol_open);
   EXPECT_EQ(solution.size(), 5);
 }
 TEST(Clipper2Tests, ExportHeaderD)
 {
   uint8_t None = 0, Intersection = 1, Union = 2, Difference = 3, Xor = 4;
   uint8_t EvenOdd = 0, NonZero = 1, Positive = 2, Negative = 3;
-  PathsD subj, clip, solution;
+  PathsS subj, clip, solution;
   //subj.push_back(MakeRandomPolyD(600, 400, 25));
   //clip.push_back(MakeRandomPolyD(600, 400, 25));
   for (int i = 1; i < 6; ++i)
-    subj.push_back(MakePathD({ -i * 20,-i * 20, i * 20,-i * 20, i * 20,i * 20, -i * 20,i * 20 }));
-  clip.push_back(MakePathD({ -90,-120,90,-120, 90,120, -90,120 }));
-  CPathsD c_subj_open = nullptr, c_sol = nullptr, c_sol_open = nullptr;
+    subj.push_back(MakePathS({ -i * 20,-i * 20, i * 20,-i * 20, i * 20,i * 20, -i * 20,i * 20 }));
+  clip.push_back(MakePathS({ -90,-120,90,-120, 90,120, -90,120 }));
+  CPathsS c_subj_open = nullptr, c_sol = nullptr, c_sol_open = nullptr;
   // Note: while CreateCPathsD isn't exported in clipper.export.h, it can still
   // be used here because we're simply statically compiling clipper.export.h.
   // Normally clipper.export.h will be compiled into a DLL/so so it can be called
   // by non C++ applications. If CreateCPathsD was an exported function and it
   // was called by a non C++ application, it would crash that application.
-  CPathsD c_subj = CreateCPaths(subj);
-  CPathsD c_clip = CreateCPaths(clip);
-  BooleanOpD(Intersection, EvenOdd, c_subj, c_subj_open, c_clip, c_sol, c_sol_open);
+  CPathsS c_subj = CreateCPaths(subj);
+  CPathsS c_clip = CreateCPaths(clip);
+  BooleanOpS(Intersection, EvenOdd, c_subj, c_subj_open, c_clip, c_sol, c_sol_open);
   solution = ConvertCPaths(c_sol);
   //clean up !!!
   delete[] c_subj;
   delete[] c_clip;
-  DisposeArrayD(c_sol);
-  DisposeArrayD(c_sol_open);
+  DisposeArrayS(c_sol);
+  DisposeArrayS(c_sol_open);
   EXPECT_EQ(solution.size(), 5);
 }
 TEST(Clipper2Tests, ExportHeaderTree64)
 {
   uint8_t None = 0, Intersection = 1, Union = 2, Difference = 3, Xor = 4;
   uint8_t EvenOdd = 0, NonZero = 1, Positive = 2, Negative = 3;
-  Paths64 subj, clip, solution;
+  PathsI subj, clip, solution;
   for (int i = 1; i < 6; ++i)
     subj.push_back(MakePath({ -i * 20,-i * 20, i * 20,-i * 20, i * 20,i * 20, -i * 20,i * 20 }));
   clip.push_back(MakePath({ -90,-120,90,-120, 90,120, -90,120 }));
-  CPaths64 c_subj_open = nullptr, c_sol = nullptr, c_sol_open = nullptr;
+  CPathsI c_subj_open = nullptr, c_sol = nullptr, c_sol_open = nullptr;
   // Note: while CreateCPaths64 isn't exported in clipper.export.h, it can still
   // be used here because we're statically compiling clipper.export.h.
   // More likely, clipper.export.h will be compiled into a DLL/so so it can be
   // called by non C++ applications. If CreateCPaths64 was an exported function
   // and it was called by a non C++ application, it would crash that application.
-  CPaths64 c_subj = CreateCPaths(subj);
-  CPaths64 c_clip = CreateCPaths(clip);
-  int64_t* c_sol_tree = nullptr;
-  BooleanOp_PolyTree64(Intersection, EvenOdd, c_subj, c_subj_open, c_clip, c_sol_tree, c_sol_open);
-  PolyTree64 sol_tree;
-  // convert CPolyTree64 to PolyTree64
+  CPathsI c_subj = CreateCPaths(subj);
+  CPathsI c_clip = CreateCPaths(clip);
+  Integer* c_sol_tree = nullptr;
+  BooleanOp_PolyTreeI(Intersection, EvenOdd, c_subj, c_subj_open, c_clip, c_sol_tree, c_sol_open);
+  PolyTreeI sol_tree;
+  // convert CPolyTreeI to PolyTreeI
   BuildPolyTree64FromCPolyTree(c_sol_tree, sol_tree);
-  // convert PolyTree64 to Paths64
-  solution = PolyTreeToPaths64(sol_tree);
+  // convert PolyTreeI to PathsI
+  solution = PolyTreeToPathsI(sol_tree);
   //clean up !!!
   delete[] c_subj;
   delete[] c_clip;
-  DisposeArray64(c_sol_tree);
-  DisposeArray64(c_sol_open);
-  PolyPath64* pp = &sol_tree;
+  DisposeArrayI(c_sol_tree);
+  DisposeArrayI(c_sol_open);
+  PolyPathI* pp = &sol_tree;
   for (int i = 0; i < 4; ++i)
   {
     EXPECT_TRUE(pp->Count() == 1); pp = pp->Child(0);
@@ -145,32 +145,32 @@ TEST(Clipper2Tests, ExportHeaderTreeD)
 {
   uint8_t None = 0, Intersection = 1, Union = 2, Difference = 3, Xor = 4;
   uint8_t EvenOdd = 0, NonZero = 1, Positive = 2, Negative = 3;
-  PathsD subj, clip, solution;
+  PathsS subj, clip, solution;
   for (int i = 1; i < 6; ++i)
-    subj.push_back(MakePathD({ -i * 20,-i * 20, i * 20,-i * 20, i * 20,i * 20, -i * 20,i * 20 }));
-  clip.push_back(MakePathD({ -90,-120,90,-120, 90,120, -90,120 }));
-  CPathsD c_subj_open = nullptr, c_sol = nullptr, c_sol_open = nullptr;
+    subj.push_back(MakePathS({ -i * 20,-i * 20, i * 20,-i * 20, i * 20,i * 20, -i * 20,i * 20 }));
+  clip.push_back(MakePathS({ -90,-120,90,-120, 90,120, -90,120 }));
+  CPathsS c_subj_open = nullptr, c_sol = nullptr, c_sol_open = nullptr;
   // Note: while CreateCPathsD isn't exported in clipper.export.h, it can still
   // be used here because we're statically compiling clipper.export.h.
   // More likely, clipper.export.h will be compiled into a DLL/so so it can be
   // called by non C++ applications. If CreateCPathsD was an exported function
   // and it was called by a non C++ application, it would crash that application.
-  CPathsD c_subj = CreateCPaths(subj);
-  CPathsD c_clip = CreateCPaths(clip);
+  CPathsS c_subj = CreateCPaths(subj);
+  CPathsS c_clip = CreateCPaths(clip);
   static const int precision = 4;
-  CPolyPathD c_sol_tree = nullptr;
-  BooleanOp_PolyTreeD(Intersection, EvenOdd, c_subj, c_subj_open, c_clip, c_sol_tree, c_sol_open, precision);
+  CPolyPathS c_sol_tree = nullptr;
+  BooleanOp_PolyTreeS(Intersection, EvenOdd, c_subj, c_subj_open, c_clip, c_sol_tree, c_sol_open, precision);
   PolyTreeD sol_tree;
-  // convert CPolyTreeD to PolyTreeD
+  // convert CPolyTreeS to PolyTreeD
   BuildPolyTreeDFromCPolyTree(c_sol_tree, sol_tree);
-  // convert PolyTreeD to PathsD
-  solution = PolyTreeToPathsD(sol_tree);
+  // convert PolyTreeD to PathsS
+  solution = PolyTreeToPathsS(sol_tree);
   //clean up !!!
   delete[] c_subj;
   delete[] c_clip;
-  DisposeArrayD(c_sol_tree);
-  DisposeArrayD(c_sol_open);
-  PolyPathD* pp = &sol_tree;
+  DisposeArrayS(c_sol_tree);
+  DisposeArrayS(c_sol_open);
+  PolyPathS* pp = &sol_tree;
   for (int i = 0; i < 4; ++i)
   {
     EXPECT_TRUE(pp->Count() == 1); pp = pp->Child(0);

--- a/CPP/Tests/TestIsCollinear.cpp
+++ b/CPP/Tests/TestIsCollinear.cpp
@@ -24,29 +24,31 @@ TEST(Clipper2Tests, TestCarryCalculation) {
   EXPECT_EQ(Clipper2Lib::Multiply(0xbb0f73d0f82e2236, 0xbbecf7dbc6147480).carry, 0x895170f4e9a216a7);
 }
 
-TEST(Clipper2Tests, TestIsCollinear) {
-  // a large integer not representable by double
-  const int64_t i = 9007199254740993;
+using Clipper2Lib::Integer;
 
-  const Clipper2Lib::Point64 pt1(0, 0);
-  const Clipper2Lib::Point64 sharedPt(i, i * 10);
-  const Clipper2Lib::Point64 pt2(i * 10, i * 100);
+TEST(Clipper2Tests, TestIsCollinear) {
+  // a large integer not representable by Scalar
+  const Integer i = 9007199254740993;
+
+  const Clipper2Lib::PointI pt1(0, 0);
+  const Clipper2Lib::PointI sharedPt((Integer)i, (Integer)((Integer)i * (Integer)10));
+  const Clipper2Lib::PointI pt2(i * (Integer)10, i * (Integer)100);
 
   EXPECT_TRUE(IsCollinear(pt1, sharedPt, pt2));
 }
 
 TEST(Clipper2Tests, TestIsCollinear2) {
   // see https://github.com/AngusJohnson/Clipper2/issues/831
-  const int64_t i = 0x4000000000000;
-  const Clipper2Lib::Path64 subject = {
-    Clipper2Lib::Point64(-i, -i),
-    Clipper2Lib::Point64( i, -i),
-    Clipper2Lib::Point64(-i,  i),
-    Clipper2Lib::Point64( i,  i)
+  const Integer i = 0x4000000000000;
+  const Clipper2Lib::PathI subject = {
+    Clipper2Lib::PointI((Integer)-i, (Integer)-i),
+    Clipper2Lib::PointI((Integer) i, (Integer)-i),
+    Clipper2Lib::PointI((Integer)-i, (Integer) i),
+    Clipper2Lib::PointI((Integer) i, (Integer) i)
   };
-  Clipper2Lib::Clipper64 clipper;
+  Clipper2Lib::ClipperI clipper;
   clipper.AddSubject({ subject });
-  Clipper2Lib::Paths64 solution;
+  Clipper2Lib::PathsI solution;
   clipper.Execute(Clipper2Lib::ClipType::Union, Clipper2Lib::FillRule::EvenOdd, solution);
   EXPECT_EQ(solution.size(), 2);
 }

--- a/CPP/Tests/TestLines.cpp
+++ b/CPP/Tests/TestLines.cpp
@@ -1,28 +1,31 @@
 #include <gtest/gtest.h>
 #include "clipper2/clipper.h"
 #include "ClipFileLoad.h"
+
+using Clipper2Lib::Scalar;
+
 TEST(Clipper2Tests, TestMultipleLines) {
   std::ifstream ifs("Lines.txt");
   ASSERT_TRUE(ifs.good());
   int test_number = 1;
   while (true)
   {
-    Clipper2Lib::Paths64 subject, subject_open, clip;
-    Clipper2Lib::Paths64 solution, solution_open;
+    Clipper2Lib::PathsI subject, subject_open, clip;
+    Clipper2Lib::PathsI solution, solution_open;
     Clipper2Lib::ClipType ct;
     Clipper2Lib::FillRule fr;
-    int64_t area, count;
+    Integer area, count;
     if (!LoadTestNum(ifs, test_number,
       subject, subject_open, clip, area, count, ct, fr)) break;
-    Clipper2Lib::Clipper64 c;
+    Clipper2Lib::ClipperI c;
     c.AddSubject(subject);
     c.AddOpenSubject(subject_open);
     c.AddClip(clip);
     EXPECT_TRUE(c.Execute(ct, fr, solution, solution_open));
-    const int64_t count2 = solution.size() + solution_open.size();
-    const int64_t count_diff = std::abs(count2 - count);
-    const double relative_count_diff = count ?
-      count_diff / static_cast<double>(count) :
+    const Integer count2 = solution.size() + solution_open.size();
+    const Integer count_diff = std::abs(count2 - count);
+    const Scalar relative_count_diff = count ?
+      count_diff / static_cast<Scalar>(count) :
       0;
     if (test_number == 1)
     {

--- a/CPP/Tests/TestOffsetOrientation.cpp
+++ b/CPP/Tests/TestOffsetOrientation.cpp
@@ -2,22 +2,22 @@
 #include "clipper2/clipper.offset.h"
 #include "ClipFileLoad.h"
 TEST(Clipper2Tests, TestOffsettingOrientation1) {
-  const Clipper2Lib::Paths64 subject = { Clipper2Lib::MakePath({ 0,0, 0,5, 5,5, 5,0 }) };
-  Clipper2Lib::Paths64 solution = Clipper2Lib::InflatePaths(subject, 1,
+  const Clipper2Lib::PathsI subject = { Clipper2Lib::MakePath({ 0,0, 0,5, 5,5, 5,0 }) };
+  Clipper2Lib::PathsI solution = Clipper2Lib::InflatePaths(subject, 1,
     Clipper2Lib::JoinType::Round, Clipper2Lib::EndType::Polygon);
   ASSERT_EQ(solution.size(), 1);
   //when offsetting, output orientation should match input
   EXPECT_TRUE(Clipper2Lib::IsPositive(subject[0]) == Clipper2Lib::IsPositive(solution[0]));
 }
 TEST(Clipper2Tests, TestOffsettingOrientation2) {
-  const Clipper2Lib::Paths64 subject = {
+  const Clipper2Lib::PathsI subject = {
     Clipper2Lib::MakePath({20, 220, 280, 220, 280, 280, 20, 280}),
     Clipper2Lib::MakePath({0, 200, 0, 300, 300, 300, 300, 200})
   };
   Clipper2Lib::ClipperOffset co;
   co.ReverseSolution(true); // could also assign using a parameter in ClipperOffset's constructor
   co.AddPaths(subject, Clipper2Lib::JoinType::Round, Clipper2Lib::EndType::Polygon);
-  Clipper2Lib::Paths64 solution;
+  Clipper2Lib::PathsI solution;
   co.Execute(5, solution);
   ASSERT_EQ(solution.size(), 2);
   // When offsetting, output orientation should match input EXCEPT when ReverseSolution == true

--- a/CPP/Tests/TestOffsets.cpp
+++ b/CPP/Tests/TestOffsets.cpp
@@ -10,19 +10,19 @@ TEST(Clipper2Tests, TestOffsets) {
   for (int test_number = 1; test_number <= 2; ++test_number)
   {
     ClipperOffset co;
-    Paths64 subject, subject_open, clip;
-    Paths64 solution, solution_open;
+    PathsI subject, subject_open, clip;
+    PathsI solution, solution_open;
     ClipType ct = ClipType::None;
     FillRule fr = FillRule::NonZero;
-    int64_t stored_area = 0, stored_count = 0;
+    Integer stored_area = 0, stored_count = 0;
     ASSERT_TRUE(LoadTestNum(ifs, test_number, subject, subject_open, clip, stored_area, stored_count, ct, fr));
     co.AddPaths(subject, JoinType::Round, EndType::Polygon);
-    Paths64 outputs;
+    PathsI outputs;
     co.Execute(1, outputs);
     // is the sum total area of the solution is positive
     const auto outer_is_positive = Area(outputs) > 0;
     // there should be exactly one exterior path
-    const auto is_positive_func = IsPositive<int64_t>;
+    const auto is_positive_func = IsPositive<Integer>;
     const auto is_positive_count = std::count_if(
       outputs.begin(), outputs.end(), is_positive_func);
     const auto is_negative_count =
@@ -34,31 +34,31 @@ TEST(Clipper2Tests, TestOffsets) {
   }
   ifs.close();
 }
-static Point64 MidPoint(const Point64& p1, const Point64& p2)
+static PointI MidPoint(const PointI& p1, const PointI& p2)
 {
-  Point64 result;
+  PointI result;
   result.x = (p1.x + p2.x) / 2;
   result.y = (p1.y + p2.y) / 2;
   return result;
 }
 TEST(Clipper2Tests, TestOffsets2) { // see #448 & #456
-  double scale = 10, delta = 10 * scale, arc_tol = 0.25 * scale;
-  Paths64 subject, solution;
+  Scalar scale = 10, delta = 10 * scale, arc_tol = 0.25 * scale;
+  PathsI subject, solution;
   ClipperOffset c;
   subject.push_back(MakePath({ 50,50, 100,50, 100,150, 50,150, 0,100 }));
   int err;
-  subject = ScalePaths<int64_t, int64_t>(subject, scale, err);
+  subject = ScalePaths<Integer, Integer>(subject, scale, err);
   c.AddPaths(subject, JoinType::Round, EndType::Polygon);
   c.ArcTolerance(arc_tol);
   c.Execute(delta, solution);
-  double min_dist = delta * 2, max_dist = 0;
-  for (const Point64& subjPt : subject[0])
+  Scalar min_dist = delta * 2, max_dist = 0;
+  for (const PointI& subjPt : subject[0])
   {
-    Point64 prevPt = solution[0][solution[0].size() - 1];
-    for (const Point64& pt : solution[0])
+    PointI prevPt = solution[0][solution[0].size() - 1];
+    for (const PointI& pt : solution[0])
     {
-      Point64 mp = MidPoint(prevPt, pt);
-      double d = Distance(mp, subjPt);
+      PointI mp = MidPoint(prevPt, pt);
+      Scalar d = Distance(mp, subjPt);
       if (d < delta * 2)
       {
         if (d < min_dist) min_dist = d;
@@ -73,7 +73,7 @@ TEST(Clipper2Tests, TestOffsets2) { // see #448 & #456
 
 TEST(Clipper2Tests, TestOffsets3) // see #424
 {
-  Paths64 subjects = {{
+  PathsI subjects = {{
    {1525311078, 1352369439}, {1526632284, 1366692987}, {1519397110, 1367437476},
    {1520246456, 1380177674}, {1520613458, 1385913385}, {1517383844, 1386238444},
    {1517771817, 1392099983}, {1518233190, 1398758441}, {1518421934, 1401883197},
@@ -93,15 +93,15 @@ TEST(Clipper2Tests, TestOffsets3) // see #424
    {1602758902, 1378489467}, {1618990858, 1376350372}, {1615058698, 1344085688},
    {1603230761, 1345700495}, {1598648484, 1346329641}, {1598931599, 1348667965},
    {1596698132, 1348993024}, {1595775386, 1342722540} }};
-  Paths64 solution = InflatePaths(subjects, -209715, JoinType::Miter, EndType::Polygon);
+  PathsI solution = InflatePaths(subjects, -209715, JoinType::Miter, EndType::Polygon);
   EXPECT_LE(solution[0].size() - subjects[0].size(), 1);
 }
 
 TEST(Clipper2Tests, TestOffsets4) // see #482
 {
-  Paths64 paths = { { {0, 0}, {20000, 200},
+  PathsI paths = { { {0, 0}, {20000, 200},
     {40000, 0}, {40000, 50000}, {0, 50000}, {0, 0}} };
-  Paths64 solution = InflatePaths(paths, -5000,
+  PathsI solution = InflatePaths(paths, -5000,
     JoinType::Square, EndType::Polygon);
   //std::cout << solution[0].size() << std::endl;
   EXPECT_EQ(solution[0].size(), 5);
@@ -127,7 +127,7 @@ TEST(Clipper2Tests, TestOffsets4) // see #482
 
 TEST(Clipper2Tests, TestOffsets5) // modified from #593 (tests offset clean up)
 {
-  Paths64 subject = {
+  PathsI subject = {
     MakePath({
       524,1483, 524,2711, 610,2744, 693,2782, 773,2825, 852,2872,
       927,2924, 999,2980, 1068,3040, 1133,3103, 1195,3171, 1252,3242,
@@ -349,13 +349,13 @@ TEST(Clipper2Tests, TestOffsets5) // modified from #593 (tests offset clean up)
       }),
     MakePath({ -47877,-47877, 84788,-47877, 84788,81432, -47877,81432 })
   };
-  Paths64 solution = InflatePaths(subject, -10000, JoinType::Round, EndType::Polygon);
+  PathsI solution = InflatePaths(subject, -10000, JoinType::Round, EndType::Polygon);
   EXPECT_EQ(solution.size(), 2);
 }
 
 TEST(Clipper2Tests, TestOffsets6) // also modified from #593 (tests rounded ends)
 {
-  Paths64 subjects = {
+  PathsI subjects = {
     {{620,620}, {-620,620}, {-620,-620}, {620,-620}},
     {{20,-277}, {42,-275}, {59,-272}, {80,-266}, {97,-261}, {114,-254},
     {135,-243}, {149,-235}, {167,-222}, {182,-211}, {197,-197},
@@ -365,21 +365,21 @@ TEST(Clipper2Tests, TestOffsets6) // also modified from #593 (tests rounded ends
     {223,-167}, {212,-181}, {197,-197}, {182,-211}, {168,-222}, {152,-233},
     {135,-243}, {114,-254}, {97,-261}, {80,-267}, {59,-272}, {42,-275}, {20,-278}}
   };
-  const double offset = -50;
+  const Scalar offset = -50;
   Clipper2Lib::ClipperOffset offseter;
-  Clipper2Lib::Paths64 tmpSubject;
+  Clipper2Lib::PathsI tmpSubject;
   offseter.AddPaths(subjects, Clipper2Lib::JoinType::Round, Clipper2Lib::EndType::Polygon);
-  Clipper2Lib::Paths64 solution;
+  Clipper2Lib::PathsI solution;
   offseter.Execute(offset, solution);
   EXPECT_EQ(solution.size(), 2);
-  double area = Area<int64_t>(solution[1]);
+  Scalar area = Area<Integer>(solution[1]);
   EXPECT_LT(area, -47500);
 }
 
 TEST(Clipper2Tests, TestOffsets7) // (#593 & #715)
 {
-  Paths64 solution;
-  Paths64 subject = { MakePath({0,0, 100,0, 100,100, 0,100}) };
+  PathsI solution;
+  PathsI subject = { MakePath({0,0, 100,0, 100,100, 0,100}) };
   solution = InflatePaths(subject, -50, JoinType::Miter, EndType::Polygon);
   EXPECT_EQ(solution.size(), 0);
   subject.push_back(MakePath({ 40,60, 60,60, 60,40, 40,40 }));
@@ -396,57 +396,57 @@ TEST(Clipper2Tests, TestOffsets7) // (#593 & #715)
 
 struct OffsetQual
 {
-  PointD smallestInSub;   // smallestInSub & smallestInSol are the points in subject and solution
-  PointD smallestInSol;   // that define the place that most falls short of the expected offset
-  PointD largestInSub;    // largestInSub & largestInSol are the points in subject and solution
-  PointD largestInSol;    // that define the place that most exceeds the expected offset
+  PointS smallestInSub;   // smallestInSub & smallestInSol are the points in subject and solution
+  PointS smallestInSol;   // that define the place that most falls short of the expected offset
+  PointS largestInSub;    // largestInSub & largestInSol are the points in subject and solution
+  PointS largestInSol;    // that define the place that most exceeds the expected offset
 };
 
 template<typename T>
-inline PointD GetClosestPointOnSegment(const PointD& offPt,
+inline PointS GetClosestPointOnSegment(const PointS& offPt,
   const Point<T>& seg1, const Point<T>& seg2)
 {
-  if (seg1.x == seg2.x && seg1.y == seg2.y) return PointD(seg1);
-  double dx = static_cast<double>(seg2.x - seg1.x);
-  double dy = static_cast<double>(seg2.y - seg1.y);
-  double q = (
-    (offPt.x - static_cast<double>(seg1.x)) * dx +
-    (offPt.y - static_cast<double>(seg1.y)) * dy) /
+  if (seg1.x == seg2.x && seg1.y == seg2.y) return PointS(seg1);
+  Scalar dx = static_cast<Scalar>(seg2.x - seg1.x);
+  Scalar dy = static_cast<Scalar>(seg2.y - seg1.y);
+  Scalar q = (
+    (offPt.x - static_cast<Scalar>(seg1.x)) * dx +
+    (offPt.y - static_cast<Scalar>(seg1.y)) * dy) /
     (Sqr(dx) + Sqr(dy));
   q = (q < 0) ? 0 : (q > 1) ? 1 : q;
-  return PointD(
-    static_cast<double>(seg1.x) + (q * dx),
-    static_cast<double>(seg1.y) + (q * dy));
+  return PointS(
+    static_cast<Scalar>(seg1.x) + (q * dx),
+    static_cast<Scalar>(seg1.y) + (q * dy));
 }
 
 template<typename T>
-static OffsetQual GetOffsetQuality(const Path<T>& subject, const Path<T>& solution, const double delta)
+static OffsetQual GetOffsetQuality(const Path<T>& subject, const Path<T>& solution, const Scalar delta)
 {
   if (!subject.size() || !solution.size()) return OffsetQual();
-  double desiredDistSqr = delta * delta;
-  double smallestSqr = desiredDistSqr, largestSqr = desiredDistSqr;
-  double deviationsSqr = 0;
+  Scalar desiredDistSqr = delta * delta;
+  Scalar smallestSqr = desiredDistSqr, largestSqr = desiredDistSqr;
+  Scalar deviationsSqr = 0;
   OffsetQual oq;
   const size_t subVertexCount = 4; // 1 .. 100 :)
-  const double subVertexFrac = 1.0 / subVertexCount;
+  const Scalar subVertexFrac = 1.0 / subVertexCount;
   Point<T> solPrev = solution[solution.size() - 1];
   for (const Point<T>& solPt0 : solution)
   {
     for (size_t i = 0; i < subVertexCount; ++i)
     {
       // divide each edge in solution into series of sub-vertices (solPt),
-      PointD solPt = PointD(
-        static_cast<double>(solPrev.x) + static_cast<double>(solPt0.x - solPrev.x) * subVertexFrac * i,
-        static_cast<double>(solPrev.y) + static_cast<double>(solPt0.y - solPrev.y) * subVertexFrac * i);
+      PointS solPt = PointS(
+        static_cast<Scalar>(solPrev.x) + static_cast<Scalar>(solPt0.x - solPrev.x) * subVertexFrac * i,
+        static_cast<Scalar>(solPrev.y) + static_cast<Scalar>(solPt0.y - solPrev.y) * subVertexFrac * i);
       // now find the closest point in subject to each of these solPt.
-      PointD closestToSolPt;
-      double closestDistSqr = std::numeric_limits<double>::infinity();
+      PointS closestToSolPt;
+      Scalar closestDistSqr = std::numeric_limits<Scalar>::infinity();
       Point<T> subPrev = subject[subject.size() - 1];
       for (size_t i = 0; i < subject.size(); ++i)
       {
-        PointD closestPt = ::GetClosestPointOnSegment(solPt, subject[i], subPrev);
+        PointS closestPt = ::GetClosestPointOnSegment(solPt, subject[i], subPrev);
         subPrev = subject[i];
-        const double sqrDist = DistanceSqr(closestPt, solPt);
+        const Scalar sqrDist = DistanceSqr(closestPt, solPt);
         if (sqrDist < closestDistSqr) {
           closestDistSqr = sqrDist;
           closestToSolPt = closestPt;
@@ -474,7 +474,7 @@ static OffsetQual GetOffsetQuality(const Path<T>& subject, const Path<T>& soluti
 
 TEST(Clipper2Tests, TestOffsets8) // (#724)
 {
-  Paths64 subject = { MakePath({
+  PathsI subject = { MakePath({
        91759700, -49711991,    83886095, -50331657,
        -872415388, -50331657,  -880288993, -49711991,  -887968725, -47868251,
        -895265482, -44845834,  -901999593, -40719165,  -908005244, -35589856,
@@ -555,12 +555,12 @@ TEST(Clipper2Tests, TestOffsets8) // (#724)
        124605260, -29584205,   119475951, -35589856,   113470300, -40719165,
        106736189, -44845834,   99439432, -47868251,    91759700, -49711991
     }) };
-  double offset = -50329979.277800001, arc_tol = 5000;
-  Paths64 solution = InflatePaths(subject, offset, JoinType::Round, EndType::Polygon, 2, arc_tol);
+  Scalar offset = -50329979.277800001, arc_tol = 5000;
+  PathsI solution = InflatePaths(subject, offset, JoinType::Round, EndType::Polygon, 2, arc_tol);
   OffsetQual oq = GetOffsetQuality(subject[0], solution[0], offset);
-  double smallestDist = Distance(oq.smallestInSub, oq.smallestInSol);
-  double largestDist = Distance(oq.largestInSub, oq.largestInSol);
-  const double rounding_tolerance = 1.0;
+  Scalar smallestDist = Distance(oq.smallestInSub, oq.smallestInSol);
+  Scalar largestDist = Distance(oq.largestInSub, oq.largestInSol);
+  const Scalar rounding_tolerance = 1.0;
   offset = std::abs(offset);
   //std::cout << std::setprecision(0) << std::fixed;
   //std::cout << "Expected delta           : " << offset << std::endl;
@@ -583,8 +583,8 @@ TEST(Clipper2Tests, TestOffsets9) // (#733)
   // solution orientations should match subject orientations UNLESS
   // reverse_solution is set true in ClipperOffset's constructor
   // start subject's orientation positive ...
-  Paths64 subject{ MakePath({100,100, 200,100, 200, 400, 100, 400}) };
-  Paths64 solution = InflatePaths(subject, 50, JoinType::Miter, EndType::Polygon);
+  PathsI subject{ MakePath({100,100, 200,100, 200, 400, 100, 400}) };
+  PathsI solution = InflatePaths(subject, 50, JoinType::Miter, EndType::Polygon);
   EXPECT_EQ(solution.size(), 1);
   EXPECT_TRUE(IsPositive(solution[0]));
   // reversing subject's orientation should not affect delta direction
@@ -617,7 +617,7 @@ TEST(Clipper2Tests, TestOffsets9) // (#733)
 
 TEST(Clipper2Tests, TestOffsets10) // see #715
 {
-  Paths64 subjects = {
+  PathsI subjects = {
          {{508685336, -435806096},
           {509492982, -434729201},
           {509615525, -434003092},
@@ -652,7 +652,7 @@ TEST(Clipper2Tests, TestOffsets10) // see #715
           {106795129, -62112022}} };
 
   Clipper2Lib::ClipperOffset offseter(2, 104857.61318750000);
-  Paths64 solution;
+  PathsI solution;
   offseter.AddPaths(subjects, Clipper2Lib::JoinType::Round, Clipper2Lib::EndType::Polygon);
   offseter.Execute(-2212495.6382562499, solution);
   EXPECT_EQ(solution.size(), 2);

--- a/CPP/Tests/TestOrientation.cpp
+++ b/CPP/Tests/TestOrientation.cpp
@@ -2,7 +2,7 @@
 #include "clipper2/clipper.h"
 using namespace Clipper2Lib;
 TEST(Clipper2Tests, TestNegativeOrientation) {
-  Paths64 subjects, clips, solution;
+  PathsI subjects, clips, solution;
   //also test MakePath using specified skip_chars (useful when pasting coords)
   subjects.push_back(MakePath({ 0,0, 0,100, 100,100, 100,0 }));
   subjects.push_back(MakePath({ 10,10, 10,110, 110,110, 110,10 }));

--- a/CPP/Tests/TestPolygons.cpp
+++ b/CPP/Tests/TestPolygons.cpp
@@ -1,12 +1,15 @@
 #include <gtest/gtest.h>
 #include "clipper2/clipper.h"
 #include "ClipFileLoad.h"
-inline Clipper2Lib::PathD MakeRandomPath(int width, int height, unsigned vertCnt)
+
+using Clipper2Lib::Scalar;
+
+inline Clipper2Lib::PathS MakeRandomPath(int width, int height, unsigned vertCnt)
 {
-  Clipper2Lib::PathD result;
+  Clipper2Lib::PathS result;
   result.reserve(vertCnt);
   for (unsigned i = 0; i < vertCnt; ++i)
-    result.push_back(Clipper2Lib::PointD(double(rand()) / RAND_MAX * width, double(rand()) / RAND_MAX * height));
+    result.push_back(Clipper2Lib::PointS(Scalar(rand()) / RAND_MAX * width, Scalar(rand()) / RAND_MAX * height));
   return result;
 }
 template <size_t N>
@@ -26,34 +29,34 @@ TEST(Clipper2Tests, TestMultiplePolygons)
   int test_number = start_num;
   while (test_number <= end_num)
   {
-    Clipper2Lib::Paths64 subject, subject_open, clip;
-    Clipper2Lib::Paths64 solution, solution_open;
+    Clipper2Lib::PathsI subject, subject_open, clip;
+    Clipper2Lib::PathsI solution, solution_open;
     Clipper2Lib::ClipType ct;
     Clipper2Lib::FillRule fr;
-    int64_t stored_area, stored_count;
+    Integer stored_area, stored_count;
     if (!LoadTestNum(ifs, test_number,
       subject, subject_open, clip, stored_area, stored_count, ct, fr)) break;
-    // check Paths64 solutions
-    Clipper2Lib::Clipper64 c;
+    // check PathsI solutions
+    Clipper2Lib::ClipperI c;
     c.AddSubject(subject);
     c.AddOpenSubject(subject_open);
     c.AddClip(clip);
     c.Execute(ct, fr, solution, solution_open);
-    const int64_t measured_area = static_cast<int64_t>(Area(solution));
-    const int64_t measured_count = static_cast<int64_t>(solution.size() + solution_open.size());
+    const Integer measured_area = static_cast<Integer>(Area(solution));
+    const Integer measured_count = static_cast<Integer>(solution.size() + solution_open.size());
     // check the polytree variant too
-    Clipper2Lib::PolyTree64 solution_polytree;
-    Clipper2Lib::Paths64 solution_polytree_open;
-    Clipper2Lib::Clipper64 clipper_polytree;
+    Clipper2Lib::PolyTreeI solution_polytree;
+    Clipper2Lib::PathsI solution_polytree_open;
+    Clipper2Lib::ClipperI clipper_polytree;
     clipper_polytree.AddSubject(subject);
     clipper_polytree.AddOpenSubject(subject_open);
     clipper_polytree.AddClip(clip);
     clipper_polytree.Execute(ct, fr, solution_polytree, solution_polytree_open);
-    const int64_t measured_area_polytree =
-      static_cast<int64_t>(solution_polytree.Area());
-    const auto solution_polytree_paths = PolyTreeToPaths64(solution_polytree);
-    const int64_t measured_count_polytree =
-      static_cast<int64_t>(solution_polytree_paths.size());
+    const Integer measured_area_polytree =
+      static_cast<Integer>(solution_polytree.Area());
+    const auto solution_polytree_paths = PolyTreeToPathsI(solution_polytree);
+    const Integer measured_count_polytree =
+      static_cast<Integer>(solution_polytree_paths.size());
     // check polygon counts
     if (stored_count <= 0)
       ; // skip count
@@ -92,16 +95,16 @@ TEST(Clipper2Tests, TestMultiplePolygons)
     ++test_number;
   }
   //EXPECT_GE(test_number, 188);
-  Clipper2Lib::PathsD subjd, clipd, solutiond;
+  Clipper2Lib::PathsS subjd, clipd, solutiond;
   Clipper2Lib::FillRule frd = Clipper2Lib::FillRule::NonZero;
 }
 TEST(Clipper2Tests, TestHorzSpikes) //#720
 {
-  Clipper2Lib::Paths64 paths = {
+  Clipper2Lib::PathsI paths = {
     Clipper2Lib::MakePath({1600,0, 1600,100, 2050,100, 2050,300, 450,300, 450, 0}),
     Clipper2Lib::MakePath({1800,200, 1800,100, 1600,100, 2000,100, 2000,200}) };
   std::cout << paths << std::endl;
-  Clipper2Lib::Clipper64 c;
+  Clipper2Lib::ClipperI c;
   c.AddSubject(paths);
   c.Execute(Clipper2Lib::ClipType::Union, Clipper2Lib::FillRule::NonZero, paths);
   EXPECT_GE(paths.size(), 1);
@@ -109,13 +112,13 @@ TEST(Clipper2Tests, TestHorzSpikes) //#720
 
 TEST(Clipper2Tests, TestCollinearOnMacOs) //#777
 {
-  Clipper2Lib::Paths64 subject;
+  Clipper2Lib::PathsI subject;
   subject.push_back(Clipper2Lib::MakePath({ 0, -453054451,0, -433253797,-455550000, 0 }));
   subject.push_back(Clipper2Lib::MakePath({ 0, -433253797,0, 0,-455550000, 0 }));
-  Clipper2Lib::Clipper64 clipper;
+  Clipper2Lib::ClipperI clipper;
   clipper.PreserveCollinear(false);
   clipper.AddSubject(subject);
-  Clipper2Lib::Paths64 solution;
+  Clipper2Lib::PathsI solution;
   clipper.Execute(Clipper2Lib::ClipType::Union, Clipper2Lib::FillRule::NonZero, solution);
   ASSERT_EQ(solution.size(), 1);
   EXPECT_EQ(solution[0].size(), 3);

--- a/CPP/Tests/TestPolytreeHoles.cpp
+++ b/CPP/Tests/TestPolytreeHoles.cpp
@@ -6,22 +6,22 @@ TEST(Clipper2Tests, TestPolytreeHoles1)
 {
   std::ifstream ifs("PolytreeHoleOwner.txt");
   ASSERT_TRUE(ifs.good());
-  Paths64 subject, subject_open, clip;
-  PolyTree64 solution;
-  Paths64 solution_open;
+  PathsI subject, subject_open, clip;
+  PolyTreeI solution;
+  PathsI solution_open;
   ClipType ct = ClipType::None;
   FillRule fr = FillRule::EvenOdd;
-  int64_t area = 0, count = 0;
+  Integer area = 0, count = 0;
   bool success = false;
   ASSERT_TRUE(LoadTestNum(ifs, 1, subject, subject_open, clip, area, count, ct, fr));
-  Clipper64 c;
+  ClipperI c;
   c.AddSubject(subject);
   c.AddOpenSubject(subject_open);
   c.AddClip(clip);
   c.Execute(ct, fr, solution, solution_open);
   EXPECT_TRUE(CheckPolytreeFullyContainsChildren(solution));
 }
-void PolyPathContainsPoint(const PolyPath64& pp, const Point64 pt, int& counter)
+void PolyPathContainsPoint(const PolyPathI& pp, const PointI pt, int& counter)
 {
   if (pp.Polygon().size() > 0)
   {
@@ -34,7 +34,7 @@ void PolyPathContainsPoint(const PolyPath64& pp, const Point64 pt, int& counter)
   for (const auto& child : pp)
     PolyPathContainsPoint(*child, pt, counter);
 }
-bool PolytreeContainsPoint(const PolyPath64& pp, const Point64 pt)
+bool PolytreeContainsPoint(const PolyPathI& pp, const PointI pt)
 {
   int counter = 0;
   for (const auto& child : pp)
@@ -42,15 +42,15 @@ bool PolytreeContainsPoint(const PolyPath64& pp, const Point64 pt)
   EXPECT_GE(counter, 0); //ie 'pt' can't be inside more holes than outers
   return counter != 0;
 }
-void GetPolyPathArea(const PolyPath64& pp, double& area)
+void GetPolyPathArea(const PolyPathI& pp, Scalar& area)
 {
   area += Area(pp.Polygon());
   for (const auto& child : pp)
     GetPolyPathArea(*child, area);
 }
-double GetPolytreeArea(const PolyPath64& pp)
+Scalar GetPolytreeArea(const PolyPathI& pp)
 {
-  double result = 0;
+  Scalar result = 0;
   for (const auto& child : pp)
     GetPolyPathArea(*child, result);
   return result;
@@ -60,16 +60,16 @@ TEST(Clipper2Tests, TestPolytreeHoles2)
   std::ifstream ifs("PolytreeHoleOwner2.txt");
   ASSERT_TRUE(ifs);
   ASSERT_TRUE(ifs.good());
-  Paths64 subject, subject_open, clip;
+  PathsI subject, subject_open, clip;
   ClipType ct = ClipType::None;
   FillRule fr = FillRule::EvenOdd;
-  int64_t area = 0, count = 0;
+  Integer area = 0, count = 0;
   ASSERT_TRUE(LoadTestNum(ifs, 1, subject, subject_open, clip, area, count, ct, fr));
-  const std::vector<Point64> points_of_interest_outside = {
-     Point64(21887, 10420),
-     Point64(21726, 10825),
-     Point64(21662, 10845),
-     Point64(21617, 10890)
+  const std::vector<PointI> points_of_interest_outside = {
+     PointI(21887, 10420),
+     PointI(21726, 10825),
+     PointI(21662, 10845),
+     PointI(21617, 10890)
   };
   // confirm that each 'points_of_interest_outside' is outside every subject,
   for (const auto& poi_outside : points_of_interest_outside)
@@ -80,11 +80,11 @@ TEST(Clipper2Tests, TestPolytreeHoles2)
         ++outside_subject_count;
     EXPECT_EQ(outside_subject_count, 0);
   }
-  const std::vector<Point64> points_of_interest_inside = {
-     Point64(21887, 10430),
-     Point64(21843, 10520),
-     Point64(21810, 10686),
-     Point64(21900, 10461)
+  const std::vector<PointI> points_of_interest_inside = {
+     PointI(21887, 10430),
+     PointI(21843, 10520),
+     PointI(21810, 10686),
+     PointI(21900, 10461)
   };
   // confirm that each 'points_of_interest_inside' is inside a subject,
   // and inside only one subject (to exclude possible subject holes)
@@ -98,18 +98,18 @@ TEST(Clipper2Tests, TestPolytreeHoles2)
     }
     EXPECT_EQ(inside_subject_count, 1);
   }
-  PolyTree64 solution_tree;
-  Paths64 solution_open;
-  Clipper64 c;
+  PolyTreeI solution_tree;
+  PathsI solution_open;
+  ClipperI c;
   c.AddSubject(subject);
   c.AddOpenSubject(subject_open);
   c.AddClip(clip);
   c.Execute(ct, FillRule::Negative, solution_tree, solution_open);
-  const auto solution_paths = PolyTreeToPaths64(solution_tree);
+  const auto solution_paths = PolyTreeToPathsI(solution_tree);
   ASSERT_FALSE(solution_paths.empty());
-  const double subject_area = -Area(subject); //negate (see fillrule)
-  const double solution_tree_area = GetPolytreeArea(solution_tree);
-  const double solution_paths_area = Area(solution_paths);
+  const Scalar subject_area = -Area(subject); //negate (see fillrule)
+  const Scalar solution_tree_area = GetPolytreeArea(solution_tree);
+  const Scalar solution_paths_area = Area(solution_paths);
   // 1a. check solution_paths_area  is smaller than subject_area
   EXPECT_LT(solution_paths_area, subject_area);
   // 1b. but not too much smaller
@@ -127,9 +127,9 @@ TEST(Clipper2Tests, TestPolytreeHoles2)
 }
 TEST(Clipper2Tests, TestPolytreeHoles3)
 {
-  Paths64 subject, clip, sol;
-  PolyTree64 solution;
-  Clipper64 c;
+  PathsI subject, clip, sol;
+  PolyTreeI solution;
+  ClipperI c;
   subject.push_back(MakePath({ 1072,501, 1072,501, 1072,539, 1072,539, 1072,539, 870,539,
     870,539, 870,539, 870,520, 894,520, 898,524, 911,524, 915,520, 915,520, 936,520,
     940,524, 953,524, 957,520, 957,520, 978,520, 983,524, 995,524, 1000,520, 1021,520,
@@ -144,9 +144,9 @@ TEST(Clipper2Tests, TestPolytreeHoles3)
 }
 TEST(Clipper2Tests, TestPolytreeHoles4) //#618
 {
-  Paths64 subject;
-  PolyTree64 solution;
-  Clipper64 c;
+  PathsI subject;
+  PolyTreeI solution;
+  ClipperI c;
   subject.push_back(MakePath({ 50,500, 50,300, 100,300, 100,350, 150,350,
     150,250, 200,250, 200,450, 350,450, 350,200, 400,200, 400,225, 450,225,
     450,175, 400,175, 400,200, 350,200, 350,175, 200,175, 200,250, 150,250,
@@ -164,15 +164,15 @@ TEST(Clipper2Tests, TestPolytreeHoles4) //#618
 }
 TEST(Clipper2Tests, TestPolytreeHoles5)
 {
-  Paths64 subject, clip;
+  PathsI subject, clip;
   subject.push_back(MakePath({ 0,30, 400,30, 400,100, 0,100 }));
   clip.push_back(MakePath({ 20,30, 30,30, 30,150, 20,150 }));
   clip.push_back(MakePath({ 200,0, 300,0, 300,30, 280,30, 280,20, 220,20, 220,30, 200,30 }));
   clip.push_back(MakePath({ 200,50, 300,50, 300,80, 200,80 }));
-  Clipper64 c;
+  ClipperI c;
   c.AddSubject(subject);
   c.AddClip(clip);
-  PolyTree64 tree;
+  PolyTreeI tree;
   c.Execute(ClipType::Xor, FillRule::NonZero, tree);
   ////std::cout << tree << std::endl;
   //Polytree with 3 polygons.
@@ -181,7 +181,7 @@ TEST(Clipper2Tests, TestPolytreeHoles5)
 }
 TEST(Clipper2Tests, TestPolytreeHoles6) //#618
 {
-  Paths64 subject, clip;
+  PathsI subject, clip;
   subject.push_back(MakePath({ 150,50, 200,50, 200,100, 150,100 }));
   subject.push_back(MakePath({ 125,100, 150,100, 150,150, 125,150 }));
   subject.push_back(MakePath({ 225,50, 300,50, 300,80, 225,80 }));
@@ -191,10 +191,10 @@ TEST(Clipper2Tests, TestPolytreeHoles6) //#618
   clip.push_back(MakePath({ 0,0, 400,0, 400,50, 0,50 }));
   clip.push_back(MakePath({ 0,100, 400,100, 400,150, 0,150 }));
   clip.push_back(MakePath({ 260,175, 325,175, 325,275, 260,275 }));
-  Clipper64 c;
+  ClipperI c;
   c.AddSubject(subject);
   c.AddClip(clip);
-  PolyTree64 tree;
+  PolyTreeI tree;
   c.Execute(ClipType::Xor, FillRule::NonZero, tree);
   ////std::cout << tree << std::endl;
   //Polytree with 3 polygons.
@@ -203,12 +203,12 @@ TEST(Clipper2Tests, TestPolytreeHoles6) //#618
 }
 TEST(Clipper2Tests, TestPolytreeHoles7) //#618
 {
-  Paths64 subject;
+  PathsI subject;
   subject.push_back(MakePath({ 0, 0, 100000, 0, 100000, 100000, 200000, 100000,
     200000, 0, 300000, 0, 300000, 200000, 0, 200000 }));
   subject.push_back(MakePath({ 0, 0, 0, -100000, 250000, -100000, 250000, 0 }));
-  PolyTree64 polytree;
-  Clipper64 c;
+  PolyTreeI polytree;
+  ClipperI c;
   c.AddSubject(subject);
   c.Execute(ClipType::Union, FillRule::NonZero, polytree);
   //std::cout << polytree << std::endl;

--- a/CPP/Tests/TestPolytreeIntersection.cpp
+++ b/CPP/Tests/TestPolytreeIntersection.cpp
@@ -3,15 +3,15 @@
 using namespace Clipper2Lib;
 TEST(Clipper2Tests, TestPolyTreeIntersection)
 {
-    Clipper64 clipper;
-    Paths64 subject;
+    ClipperI clipper;
+    PathsI subject;
     subject.push_back(MakePath({ 0,0, 0,5, 5,5, 5,0 }));
     clipper.AddSubject(subject);
-    Paths64 clip;
+    PathsI clip;
     clip.push_back(MakePath({ 1,1,  1,6,  6,6,  6,1 }));
     clipper.AddClip (clip);
-    PolyTree64 solution;
-    Paths64 open_paths;
+    PolyTreeI solution;
+    PathsI open_paths;
     if (IsPositive(subject[0]))
       clipper.Execute(ClipType::Intersection,
         FillRule::Positive, solution, open_paths);

--- a/CPP/Tests/TestPolytreeUnion.cpp
+++ b/CPP/Tests/TestPolytreeUnion.cpp
@@ -2,13 +2,13 @@
 #include "clipper2/clipper.h"
 using namespace Clipper2Lib;
 TEST(Clipper2Tests, TestPolytreeUnion) {
-    Paths64 subject;
+    PathsI subject;
     subject.push_back(MakePath({ 0,0, 0,5, 5,5, 5,0 }));
     subject.push_back(MakePath({ 1,1, 1,6, 6,6, 6,1 }));
-    Clipper64 clipper;
+    ClipperI clipper;
     clipper.AddSubject(subject);
-    PolyTree64 solution;
-    Paths64 open_paths;
+    PolyTreeI solution;
+    PathsI open_paths;
     if (IsPositive(subject[0]))
       clipper.Execute(ClipType::Union,
         FillRule::Positive, solution, open_paths);

--- a/CPP/Tests/TestRandomPaths.cpp
+++ b/CPP/Tests/TestRandomPaths.cpp
@@ -2,6 +2,10 @@
 #include "clipper2/clipper.h"
 #include <fstream>
 #include <random>
+
+using Clipper2Lib::Scalar;
+using Clipper2Lib::Integer;
+
 int GenerateRandomInt(std::default_random_engine& rng, int min_value, int max_value)
 {
   if (min_value == max_value)
@@ -9,12 +13,12 @@ int GenerateRandomInt(std::default_random_engine& rng, int min_value, int max_va
   std::uniform_int_distribution<int> distribution(min_value, max_value);
   return distribution(rng);
 }
-Clipper2Lib::Paths64 GenerateRandomPaths(std::default_random_engine& rng, int min_path_count, int max_complexity)
+Clipper2Lib::PathsI GenerateRandomPaths(std::default_random_engine& rng, int min_path_count, int max_complexity)
 {
   std::uniform_int_distribution<int> first_point_coordinate_distribution(-max_complexity, max_complexity * 2);
   std::uniform_int_distribution<int> difference_to_previous_point_distribution(-5, 5);
   const int path_count = GenerateRandomInt(rng, min_path_count, max_complexity);
-  Clipper2Lib::Paths64 result(path_count);
+  Clipper2Lib::PathsI result(path_count);
   for (int path = 0; path < path_count; ++path)
   {
     const int min_point_count = 0;
@@ -55,24 +59,24 @@ TEST(Clipper2Tests, TestRandomPaths)
     const Clipper2Lib::ClipType ct = static_cast<Clipper2Lib::ClipType>(GenerateRandomInt(rng, 0, 4));
     const Clipper2Lib::FillRule fr = static_cast<Clipper2Lib::FillRule>(GenerateRandomInt(rng, 0, 3));
     //SaveInputToFile(subject, subject_open, clip, ct, fr);
-    Clipper2Lib::Paths64 solution, solution_open;
-    Clipper2Lib::Clipper64 c;
+    Clipper2Lib::PathsI solution, solution_open;
+    Clipper2Lib::ClipperI c;
     c.AddSubject(subject);
     c.AddOpenSubject(subject_open);
     c.AddClip(clip);
     c.Execute(ct, fr, solution, solution_open);
-    const int64_t area_paths = static_cast<int64_t>(Area(solution));
-    const int64_t count_paths = solution.size() + solution_open.size();
-    Clipper2Lib::PolyTree64 solution_polytree;
-    Clipper2Lib::Paths64 solution_polytree_open;
-    Clipper2Lib::Clipper64 clipper_polytree;
+    const Integer area_paths = static_cast<Integer>(Area(solution));
+    const Integer count_paths = solution.size() + solution_open.size();
+    Clipper2Lib::PolyTreeI solution_polytree;
+    Clipper2Lib::PathsI solution_polytree_open;
+    Clipper2Lib::ClipperI clipper_polytree;
     clipper_polytree.AddSubject(subject);
     clipper_polytree.AddOpenSubject(subject_open);
     clipper_polytree.AddClip(clip);
     clipper_polytree.Execute(ct, fr, solution_polytree, solution_polytree_open);
-    const auto solution_polytree_paths = PolyTreeToPaths64(solution_polytree);
-    const int64_t area_polytree = static_cast<int64_t>(Area(solution_polytree_paths));
-    const int64_t count_polytree = solution_polytree_paths.size() + solution_polytree_open.size();
+    const auto solution_polytree_paths = PolyTreeToPathsI(solution_polytree);
+    const Integer area_polytree = static_cast<Integer>(Area(solution_polytree_paths));
+    const Integer count_polytree = solution_polytree_paths.size() + solution_polytree_open.size();
     EXPECT_EQ(area_paths, area_polytree);
     // polytree does an additional bounds check on each path
     // and discards paths with empty bounds, so count_polytree

--- a/CPP/Tests/TestRectClip.cpp
+++ b/CPP/Tests/TestRectClip.cpp
@@ -3,8 +3,8 @@
 using namespace Clipper2Lib;
 TEST(Clipper2Tests, TestRectClip)
 {
-  Paths64 sub, clp, sol;
-  Rect64 rect = Rect64(100, 100, 700, 500);
+  PathsI sub, clp, sol;
+  RectI rect = RectI(100, 100, 700, 500);
   clp.push_back(rect.AsPath());
   sub.push_back(MakePath({ 100,100, 700,100, 700,500, 100,500 }));
   sol = RectClip(rect, sub);
@@ -23,7 +23,7 @@ TEST(Clipper2Tests, TestRectClip)
   EXPECT_TRUE(Area(sol) == Area(sub));
   sub.clear();
   clp.clear();
-  rect = Rect64(390, 290, 410, 310);
+  rect = RectI(390, 290, 410, 310);
   clp.push_back(rect.AsPath());
   sub.push_back(MakePath({ 410,290, 500,290, 500,310, 410,310 }));
   sol = RectClip(rect, sub);
@@ -39,7 +39,7 @@ TEST(Clipper2Tests, TestRectClip)
   sub.clear();
   sub.push_back(MakePath({ 208,66, 366,112, 402,303,
     234,332, 233,262, 243,140, 215,126, 40,172 }));
-  rect = Rect64(237, 164, 322, 248);
+  rect = RectI(237, 164, 322, 248);
   sol = RectClip(rect, sub);
   const auto solBounds = GetBounds(sol);
   EXPECT_EQ(solBounds.Width(), rect.Width());
@@ -47,16 +47,16 @@ TEST(Clipper2Tests, TestRectClip)
 }
 TEST(Clipper2Tests, TestRectClip2) //#597
 {
-  Clipper2Lib::Rect64 rect(54690, 0, 65628, 6000);
-  Clipper2Lib::Paths64 subject {{{700000, 6000}, { 0, 6000 }, { 0, 5925 }, { 700000, 5925 }}};
-  Clipper2Lib::Paths64 solution = Clipper2Lib::RectClip(rect, subject);
+  Clipper2Lib::RectI rect(54690, 0, 65628, 6000);
+  Clipper2Lib::PathsI subject {{{700000, 6000}, { 0, 6000 }, { 0, 5925 }, { 700000, 5925 }}};
+  Clipper2Lib::PathsI solution = Clipper2Lib::RectClip(rect, subject);
   //std::cout << solution << std::endl;
   EXPECT_TRUE(solution.size() == 1 && solution[0].size() == 4);
 }
 TEST(Clipper2Tests, TestRectClip3) //#637
 {
-  Rect64 r(-1800000000LL, -137573171LL, -1741475021LL, 3355443LL);
-  Paths64 subject, clip, solution;
+  RectI r(-1800000000LL, -137573171LL, -1741475021LL, 3355443LL);
+  PathsI subject, clip, solution;
   subject.push_back(MakePath({ -1800000000LL, 10005000LL,
     -1800000000LL, -5000LL, -1789994999LL, -5000LL, -1789994999LL, 10005000LL }));
   clip.push_back(r.AsPath());

--- a/CPP/Tests/TestSimplifyPath.cpp
+++ b/CPP/Tests/TestSimplifyPath.cpp
@@ -2,10 +2,10 @@
 #include <gtest/gtest.h>
 using namespace Clipper2Lib;
 TEST(Clipper2Tests, TestSimplifyPath) {
-  Path64 input1 = MakePath({
+  PathI input1 = MakePath({
       0,0, 1,1, 0,20, 0,21, 1,40, 0,41, 0,60, 0,61, 0,80, 1,81, 0,100
   });
-  Path64 output1 = SimplifyPath(input1, 2, false);
+  PathI output1 = SimplifyPath(input1, 2, false);
   EXPECT_EQ(Length(output1), 100);
   EXPECT_EQ(output1.size(), 2);
 }

--- a/CPP/Tests/TestTrimCollinear.cpp
+++ b/CPP/Tests/TestTrimCollinear.cpp
@@ -2,22 +2,22 @@
 #include "clipper2/clipper.h"
 using namespace Clipper2Lib;
 TEST(Clipper2Tests, TestTrimCollinear) {
-  Path64 input1 =
+  PathI input1 =
     MakePath({ 10,10, 10,10, 50,10, 100,10, 100,100, 10,100, 10,10, 20,10 });
-  Path64 output1 = TrimCollinear(input1, false);
+  PathI output1 = TrimCollinear(input1, false);
   EXPECT_EQ(output1.size(), 4);
-  Path64 input2 =
+  PathI input2 =
     MakePath({ 10,10, 10,10, 100,10, 100,100, 10,100, 10,10, 10,10 });
-  Path64 output2 = TrimCollinear(input2, true);
+  PathI output2 = TrimCollinear(input2, true);
   EXPECT_EQ(output2.size(), 5);
-  Path64 input3 = MakePath({ 10,10, 10,50, 10,10, 50,10,50,50,
+  PathI input3 = MakePath({ 10,10, 10,50, 10,10, 50,10,50,50,
     50,10, 70,10, 70,50, 70,10, 50,10, 100,10, 100,50, 100,10 });
-  Path64 output3 = TrimCollinear(input3);
+  PathI output3 = TrimCollinear(input3);
   EXPECT_EQ(output3.size(), 0);
-  Path64 input4 = MakePath({ 2,3, 3,4, 4,4, 4,5, 7,5,
+  PathI input4 = MakePath({ 2,3, 3,4, 4,4, 4,5, 7,5,
     8,4, 8,3, 9,3, 8,3, 7,3, 6,3, 5,3, 4,3, 3,3, 2,3 });
-  Path64 output4a = TrimCollinear(input4);
-  Path64 output4b = TrimCollinear(output4a);
+  PathI output4a = TrimCollinear(input4);
+  PathI output4b = TrimCollinear(output4a);
   int area4a = static_cast<int>(Area(output4a));
   int area4b = static_cast<int>(Area(output4b));
   EXPECT_EQ(output4a.size(), 7);

--- a/CPP/Utils/ClipFileLoad.cpp
+++ b/CPP/Utils/ClipFileLoad.cpp
@@ -9,7 +9,7 @@ using namespace std;
 using namespace Clipper2Lib;
 
 bool GetInt(string::const_iterator& s_it,
-  const string::const_iterator& it_end, int64_t& value)
+  const string::const_iterator& it_end, Integer& value)
 {
   value = 0;
   while (s_it != it_end && *s_it == ' ') ++s_it;
@@ -19,7 +19,7 @@ bool GetInt(string::const_iterator& s_it,
   string::const_iterator s_it2 = s_it;
   while (s_it != it_end && *s_it >= '0' && *s_it <= '9')
   {
-    value = value * 10 + static_cast<int64_t>(*s_it++) - 48;
+    value = value * 10 + static_cast<Integer>(*s_it++) - 48;
   }
 
   if (s_it == s_it2) return false; //no value
@@ -30,19 +30,19 @@ bool GetInt(string::const_iterator& s_it,
   return true;
 }
 
-bool GetPath(const string& line, Paths64& paths)
+bool GetPath(const string& line, PathsI& paths)
 {
-  Path64 p;
-  int64_t x = 0, y = 0;
+  PathI p;
+  Integer x = 0, y = 0;
   string::const_iterator s_it = line.cbegin(), s_end = line.cend();
   while (GetInt(s_it, s_end, x) && GetInt(s_it, s_end, y))
-    p.push_back(Point64(x, y));
+    p.push_back(PointI(x, y));
   if (p.empty()) return false;
   paths.push_back(p);
   return true;
 }
 
-void GetPaths(ifstream& source, Paths64& paths)
+void GetPaths(ifstream& source, PathsI& paths)
 {
   while (true)
   {
@@ -57,8 +57,8 @@ void GetPaths(ifstream& source, Paths64& paths)
 }
 
 bool LoadTestNum(ifstream &source, int test_num,
-  Paths64 &subj, Paths64 &subj_open, Paths64 &clip,
-  int64_t& area, int64_t& count, ClipType &ct, FillRule &fr)
+  PathsI &subj, PathsI &subj_open, PathsI &clip,
+  Integer& area, Integer& count, ClipType &ct, FillRule &fr)
 {
   string line;
   area = 0; count = 0;

--- a/CPP/Utils/ClipFileLoad.h
+++ b/CPP/Utils/ClipFileLoad.h
@@ -14,6 +14,8 @@
 #include <unistd.h>
 #endif
 
+using Clipper2Lib::Integer;
+
 inline bool FileExists(const std::string& name)
 {
   struct stat buffer;
@@ -21,12 +23,12 @@ inline bool FileExists(const std::string& name)
 }
 
 bool LoadTestNum(std::ifstream& source, int test_num,
-  Clipper2Lib::Paths64& subj, Clipper2Lib::Paths64& subj_open, Clipper2Lib::Paths64& clip,
-  int64_t& area, int64_t& count, Clipper2Lib::ClipType& ct, Clipper2Lib::FillRule& fr);
+  Clipper2Lib::PathsI& subj, Clipper2Lib::PathsI& subj_open, Clipper2Lib::PathsI& clip,
+  Integer& area, Integer& count, Clipper2Lib::ClipType& ct, Clipper2Lib::FillRule& fr);
 
 static bool LoadTest(std::ifstream& source,
-  Clipper2Lib::Paths64& subj, Clipper2Lib::Paths64& subj_open, Clipper2Lib::Paths64& clip,
-  int64_t& area, int64_t& count, Clipper2Lib::ClipType& ct, Clipper2Lib::FillRule& fr)
+  Clipper2Lib::PathsI& subj, Clipper2Lib::PathsI& subj_open, Clipper2Lib::PathsI& clip,
+  Integer& area, Integer& count, Clipper2Lib::ClipType& ct, Clipper2Lib::FillRule& fr)
 {
   return LoadTestNum(source, 1, subj, subj_open, clip, area, count, ct, fr);
 }

--- a/CPP/Utils/ClipFileSave.cpp
+++ b/CPP/Utils/ClipFileSave.cpp
@@ -210,14 +210,14 @@ public:
 }; //BMH_Search class
 
 
-void PathsToStream(const Paths64& paths, std::ostream& stream)
+void PathsToStream(const PathsI& paths, std::ostream& stream)
 {
-  for (Paths64::const_iterator paths_it = paths.cbegin(); 
+  for (PathsI::const_iterator paths_it = paths.cbegin(); 
     paths_it != paths.cend(); ++paths_it)
   {
     //watch out for empty paths
     if (paths_it->cbegin() == paths_it->cend()) continue;
-    Path64::const_iterator path_it, path_it_last;
+    PathI::const_iterator path_it, path_it_last;
     for (path_it = paths_it->cbegin(), path_it_last = --paths_it->cend();
       path_it != path_it_last; ++path_it)
       stream << *path_it << ", ";
@@ -226,7 +226,7 @@ void PathsToStream(const Paths64& paths, std::ostream& stream)
 }
 
 static bool GetInt(string::const_iterator& s_it,
-  const string::const_iterator& it_end, int64_t& value)
+  const string::const_iterator& it_end, Integer& value)
 {
   value = 0;
   while (s_it != it_end && *s_it == ' ') ++s_it;
@@ -236,7 +236,7 @@ static bool GetInt(string::const_iterator& s_it,
   string::const_iterator s_it2 = s_it;
   while (s_it != it_end && *s_it >= '0' && *s_it <= '9')
   {
-    value = value * 10 + static_cast<int64_t>(*s_it++) - 48;
+    value = value * 10 + static_cast<Integer>(*s_it++) - 48;
   }
   if (s_it == s_it2) return false; //no value
   //trim trailing space and a comma if present
@@ -247,13 +247,13 @@ static bool GetInt(string::const_iterator& s_it,
 }
 
 bool SaveTest(const std::string& filename, bool append,
-  const Paths64* subj, const Paths64* subj_open, const Paths64* clip, 
-  int64_t area, int64_t count, ClipType ct, FillRule fr)
+  const PathsI* subj, const PathsI* subj_open, const PathsI* clip, 
+  Integer area, Integer count, ClipType ct, FillRule fr)
 {
   string line;
   bool found = false;
   int last_cap_pos = 0, curr_cap_pos = 0;
-  int64_t last_test_no = 0;
+  Integer last_test_no = 0;
   if (append && FileExists(filename)) //get the number of the preceeding test
   {
     ifstream file;

--- a/CPP/Utils/ClipFileSave.h
+++ b/CPP/Utils/ClipFileSave.h
@@ -10,8 +10,8 @@
 namespace Clipper2Lib {
 
   bool SaveTest(const std::string& filename, bool append,
-    const Paths64* subj, const Paths64* subj_open, const Paths64* clip, 
-    int64_t area, int64_t count, ClipType ct, FillRule fr);
+    const PathsI* subj, const PathsI* subj_open, const PathsI* clip, 
+    Integer area, Integer count, ClipType ct, FillRule fr);
 
 } //end namespace
 

--- a/CPP/Utils/Colors.h
+++ b/CPP/Utils/Colors.h
@@ -3,6 +3,8 @@
 
 #include <cstdlib>
 
+using Clipper2Lib::Scalar;
+
 struct Hsl {
   uint8_t alpha = 0;
   uint8_t hue = 0;
@@ -44,10 +46,10 @@ Color32 HslToRgb(Hsl hsl)
   return result;
 }
 
-uint32_t RainbowColor(double frac, 
+uint32_t RainbowColor(Scalar frac, 
   uint8_t luminance = 128, uint8_t alpha = 255)
 {
-  frac = static_cast<double>(frac - static_cast<int>(frac));
+  frac = static_cast<Scalar>(frac - static_cast<int>(frac));
   Hsl hsl(alpha, static_cast<uint8_t>(frac * 255), 255, luminance);
   Color32 result = HslToRgb(hsl);
   return result.color;

--- a/CPP/Utils/CommonUtils.h
+++ b/CPP/Utils/CommonUtils.h
@@ -5,7 +5,7 @@
 #include <random>
 #include "clipper2/clipper.h"
 
-Clipper2Lib::Path64 MakeRandomPoly(int width, int height, unsigned vertCnt)
+Clipper2Lib::PathI MakeRandomPoly(int width, int height, unsigned vertCnt)
 {
   std::random_device rd;
   std::mt19937 gen(rd());
@@ -13,14 +13,14 @@ Clipper2Lib::Path64 MakeRandomPoly(int width, int height, unsigned vertCnt)
   std::uniform_int_distribution<> h(0, height);
 
   using namespace Clipper2Lib;
-  Path64 result;
+  PathI result;
   result.reserve(vertCnt);
   for (unsigned i = 0; i < vertCnt; ++i)
-    result.push_back(Point64(w(gen), h(gen)));
+    result.push_back(PointI(w(gen), h(gen)));
   return result;
 }
 
-Clipper2Lib::PathD MakeRandomPolyD(int width, int height, unsigned vertCnt)
+Clipper2Lib::PathS MakeRandomPolyD(int width, int height, unsigned vertCnt)
 {
   std::random_device rd;
   std::mt19937 gen(rd());
@@ -28,10 +28,10 @@ Clipper2Lib::PathD MakeRandomPolyD(int width, int height, unsigned vertCnt)
   std::uniform_int_distribution<> h(0, height);
 
   using namespace Clipper2Lib;
-  PathD result;
+  PathS result;
   result.reserve(vertCnt);
   for (unsigned i = 0; i < vertCnt; ++i)
-    result.push_back(PointD(w(gen), h(gen)));
+    result.push_back(PointS(w(gen), h(gen)));
   return result;
 }
 

--- a/CPP/Utils/Timer.h
+++ b/CPP/Utils/Timer.h
@@ -33,7 +33,8 @@ private:
   std::streamsize old_precision = std::cout.precision(0);
   std::ios_base::fmtflags old_flags = std::cout.flags();
   std::chrono::high_resolution_clock::time_point time_started_;
-  std::chrono::high_resolution_clock::duration duration_ = {};
+  typedef std::chrono::duration<uint64_t, std::nano> nanosec;
+  nanosec duration_ = {};
   bool paused_ = false;
 
 public:
@@ -67,7 +68,7 @@ public:
     paused_ = true;
   }
 
-  int64_t elapsed_nano() // result in nano-seconds
+  uint64_t elapsed_nano() // result in nano-seconds
   {
     if (!paused_)
     {
@@ -75,13 +76,13 @@ public:
         std::chrono::high_resolution_clock::now();
       duration_ += (now - time_started_);
     }
-    return std::chrono::duration_cast<std::chrono::nanoseconds>(duration_).count();
+    return std::chrono::duration_cast<nanosec>(duration_).count();
   }
 
   std::string elapsed_str() // result as string
   {
-    int64_t nano_secs = elapsed_nano();
-    int nsecs_log10 = static_cast<int>(std::log10(nano_secs));
+    uint64_t nano_secs = elapsed_nano();
+    uint64_t nsecs_log10 = static_cast<uint64_t>(std::log10(nano_secs));
     std::ostringstream os{};
     os.precision(static_cast<uint8_t>(2.0 - (nsecs_log10 % 3)));
     os << std::fixed;

--- a/CPP/Utils/clipper.svg.h
+++ b/CPP/Utils/clipper.svg.h
@@ -17,17 +17,17 @@ namespace Clipper2Lib {
 
     class PathInfo {
     private:
-        PathsD paths_;
+        PathsS paths_;
         bool is_open_path;
         FillRule fillrule_;
         unsigned brush_color_;
         unsigned pen_color_;
-        double pen_width_;
+        Scalar pen_width_;
         bool show_coords_;
 
     public:
-        PathInfo(const PathsD& paths, bool is_open, FillRule fillrule,
-            unsigned brush_clr, unsigned pen_clr, double pen_width, bool show_coords) :
+        PathInfo(const PathsS& paths, bool is_open, FillRule fillrule,
+            unsigned brush_clr, unsigned pen_clr, Scalar pen_width, bool show_coords) :
             paths_(paths), is_open_path(is_open), fillrule_(fillrule),
             brush_color_(brush_clr), pen_color_(pen_clr),
             pen_width_(pen_width), show_coords_(show_coords) {};
@@ -56,11 +56,11 @@ namespace Clipper2Lib {
         unsigned font_color = 0xFF000000;
         unsigned font_weight = 600;
         unsigned font_size = 11;
-        double x = 0;
-        double y = 0;
+        Scalar x = 0;
+        Scalar y = 0;
 
         TextInfo(const std::string &txt, const std::string &fnt_name, unsigned color,
-            unsigned weight, unsigned size, double coord_x, double coord_y) :
+            unsigned weight, unsigned size, Scalar coord_x, Scalar coord_y) :
             text(txt), font_name(fnt_name), font_color(color), font_weight(weight), font_size(size),
             x(coord_x), y(coord_y) {};
         friend class SvgWriter;
@@ -69,12 +69,12 @@ namespace Clipper2Lib {
     typedef std::vector< TextInfo* > TextInfoList;
 
   private:
-      double scale_;
+      Scalar scale_;
       FillRule fill_rule_;
       CoordsStyle coords_style;
       TextInfoList text_infos;
       PathInfoList path_infos;
-      void DrawCircle(std::ofstream& file, double x, double y, double radius);
+      void DrawCircle(std::ofstream& file, Scalar x, Scalar y, Scalar radius);
   public:
     explicit SvgWriter(int precision = 0)
     {
@@ -90,15 +90,15 @@ namespace Clipper2Lib {
     void Clear();
     FillRule Fill_Rule() { return fill_rule_; }
     void SetCoordsStyle(const std::string &font_name, unsigned font_color, unsigned font_size);
-    void AddText(const std::string &text, unsigned font_color, unsigned font_size, double x, double y);
-    void AddPath(const Path64& path, bool is_open, FillRule fillrule,
-      unsigned brush_color, unsigned pen_color, double pen_width, bool show_coords);
-    void AddPath(const PathD& path, bool is_open, FillRule fillrule,
-      unsigned brush_color, unsigned pen_color, double pen_width, bool show_coords);
-    void AddPaths(const PathsD& paths, bool is_open, FillRule fillrule,
-      unsigned brush_color, unsigned pen_color, double pen_width, bool show_coords);
-    void AddPaths(const Paths64& paths, bool is_open, FillRule fillrule,
-      unsigned brush_color, unsigned pen_color, double pen_width, bool show_coords);
+    void AddText(const std::string &text, unsigned font_color, unsigned font_size, Scalar x, Scalar y);
+    void AddPath(const PathI& path, bool is_open, FillRule fillrule,
+      unsigned brush_color, unsigned pen_color, Scalar pen_width, bool show_coords);
+    void AddPath(const PathS& path, bool is_open, FillRule fillrule,
+      unsigned brush_color, unsigned pen_color, Scalar pen_width, bool show_coords);
+    void AddPaths(const PathsS& paths, bool is_open, FillRule fillrule,
+      unsigned brush_color, unsigned pen_color, Scalar pen_width, bool show_coords);
+    void AddPaths(const PathsI& paths, bool is_open, FillRule fillrule,
+      unsigned brush_color, unsigned pen_color, Scalar pen_width, bool show_coords);
     bool SaveToFile(const std::string &filename, int max_width, int max_height, int margin);
   };
 
@@ -116,7 +116,7 @@ namespace Clipper2Lib {
       std::string xml;
       bool LoadFromFile(const std::string &filename);
       void Clear() { path_infos.clear(); };
-      PathsD GetPaths();
+      PathsS GetPaths();
   };
 
 }

--- a/CPP/Utils/clipper.svg.utils.h
+++ b/CPP/Utils/clipper.svg.utils.h
@@ -44,13 +44,13 @@ namespace Clipper2Lib {
   //    we can't displaying these paths accurately in SVG
   //    without (safely) changing the fill rule
 
-  inline void SvgAddSubject(SvgWriter& svg, const PathsD& path, FillRule fillrule)
+  inline void SvgAddSubject(SvgWriter& svg, const PathsS& path, FillRule fillrule)
   {
     if (svg.Fill_Rule() == FillRule::Positive ||
       svg.Fill_Rule() == FillRule::Negative)
     {
       svg.AddPaths(path, false, fillrule, 0x0, subj_stroke_clr, 0.8, false);
-      PathsD tmp = Union(path, svg.Fill_Rule());
+      PathsS tmp = Union(path, svg.Fill_Rule());
       svg.AddPaths(tmp, false, fillrule, subj_brush_clr, subj_stroke_clr, 0.8, false);
     }
     else
@@ -58,15 +58,15 @@ namespace Clipper2Lib {
   }
 
 
-  inline void SvgAddSubject(SvgWriter& svg, const Paths64& paths, FillRule fillrule)
+  inline void SvgAddSubject(SvgWriter& svg, const PathsI& paths, FillRule fillrule)
   {
-    PathsD tmp = TransformPaths<double, int64_t>(paths);
+    PathsS tmp = TransformPaths<Scalar, Integer>(paths);
     svg.AddPaths(tmp, false, fillrule, subj_brush_clr, subj_stroke_clr, 0.8, false);
   }
 
 
   inline void SvgAddOpenSubject(SvgWriter& svg,
-    const PathsD& path, FillRule fillrule = FillRule::EvenOdd, bool is_joined = false)
+    const PathsS& path, FillRule fillrule = FillRule::EvenOdd, bool is_joined = false)
   {
     if (is_joined)
       svg.AddPaths(path, false, fillrule, subj_brush_clr, subj_stroke_clr, 1.3, false);
@@ -76,50 +76,50 @@ namespace Clipper2Lib {
 
 
   inline void SvgAddOpenSubject(SvgWriter& svg,
-    const Paths64& path, FillRule fillrule = FillRule::EvenOdd, bool is_joined = false)
+    const PathsI& path, FillRule fillrule = FillRule::EvenOdd, bool is_joined = false)
   {
-    svg.AddPaths(TransformPaths<double, int64_t>(path),
+    svg.AddPaths(TransformPaths<Scalar, Integer>(path),
       !is_joined, fillrule, 0x0, 0xCCB3B3DA, 1.3, false);
   }
 
 
-  inline void SvgAddClip(SvgWriter& svg, const PathsD& path, FillRule fillrule)
+  inline void SvgAddClip(SvgWriter& svg, const PathsS& path, FillRule fillrule)
   {
     svg.AddPaths(path, false, fillrule, clip_brush_clr, clip_stroke_clr, 0.8, false);
   }
 
 
-  inline void SvgAddClip(SvgWriter& svg, const Paths64& paths, FillRule fillrule)
+  inline void SvgAddClip(SvgWriter& svg, const PathsI& paths, FillRule fillrule)
   {
-    PathsD tmp = TransformPaths<double, int64_t>(paths);
+    PathsS tmp = TransformPaths<Scalar, Integer>(paths);
     svg.AddPaths(tmp, false, fillrule, clip_brush_clr, clip_stroke_clr, 0.8, false);
   }
 
 
-  inline void SvgAddSolution(SvgWriter& svg, const PathsD &path, FillRule fillrule, bool show_coords)
+  inline void SvgAddSolution(SvgWriter& svg, const PathsS &path, FillRule fillrule, bool show_coords)
   {
     svg.AddPaths(path, false, fillrule, solution_brush_clr, 0xFF003300, 1.2, show_coords);
   }
 
 
-  inline void SvgAddSolution(SvgWriter& svg, const Paths64 &path, FillRule fillrule, bool show_coords)
+  inline void SvgAddSolution(SvgWriter& svg, const PathsI &path, FillRule fillrule, bool show_coords)
   {
-    svg.AddPaths(TransformPaths<double, int64_t>(path),
+    svg.AddPaths(TransformPaths<Scalar, Integer>(path),
       false, fillrule, solution_brush_clr, 0xFF003300, 1.0, show_coords);
   }
 
 
-  inline void SvgAddOpenSolution(SvgWriter& svg, const PathsD& path, FillRule fillrule,
+  inline void SvgAddOpenSolution(SvgWriter& svg, const PathsS& path, FillRule fillrule,
     bool show_coords, bool is_joined = false)
   {
     svg.AddPaths(path, !is_joined, fillrule, 0x0, 0xFF006600, 1.8, show_coords);
   }
 
 
-  inline void SvgAddOpenSolution(SvgWriter& svg, const Paths64& path,
+  inline void SvgAddOpenSolution(SvgWriter& svg, const PathsI& path,
     FillRule fillrule, bool show_coords, bool is_joined = false)
   {
-    svg.AddPaths(TransformPaths<double, int64_t>(path),
+    svg.AddPaths(TransformPaths<Scalar, Integer>(path),
       !is_joined, fillrule, 0x0, 0xFF006600, 1.8, show_coords);
   }
 


### PR DESCRIPTION
First step to have Clipper2 compiling on arbitrary type.
The point of the PR is to prepare the future work to have Clipper2 working with various precision.
Open to comment.
Suffix of "I" (for integer) instead of "64" (for int64_t) and "S" (for Scalar) instead of "D" (for double).
```cpp
#ifndef Scalar
  // Use double as default
  typedef double Scalar;
#endif
#ifndef Integer
  // Use 64 bits as default
  typedef int64_t Integer;
#endif
  typedef std::make_unsigned_t<Integer> UInteger;
```
Performance Impact:
{double, int64_t}:
```
Edge Count: 1000 = 67.0 millisecs
Edge Count: 2000 = 249 millisecs
Edge Count: 3000 = 739 millisecs
Edge Count: 4000 = 1.46 secs
Edge Count: 5000 = 3.29 secs
Edge Count: 6000 = 7.75 secs
Edge Count: 7000 = 14.6 secs
28.2 secs
```
{float, int32_t}:
```
Complex Polygons Benchmark:
Edge Count: 1000 = 69.0 millisecs
Edge Count: 2000 = 257 millisecs
Edge Count: 3000 = 747 millisecs
Edge Count: 4000 = 1.42 secs
Edge Count: 5000 = 3.18 secs
Edge Count: 6000 = 7.25 secs
Edge Count: 7000 = 13.6 secs
26.6 secs
```
{float, int16_t}:
```
Complex Polygons Benchmark:
Edge Count: 1000 = 63.6 millisecs
Edge Count: 2000 = 247 millisecs
Edge Count: 3000 = 801 millisecs
Edge Count: 4000 = 1.47 secs
Edge Count: 5000 = 3.32 secs
Edge Count: 6000 = 7.13 secs
Edge Count: 7000 = 13.0 secs
26.0 secs
```
The idea the prepare future work to have Clipper2 independant of data type storage.
Scalar could be = { double, float, float16_t }
Integer could be = { int64_t, int32_t, int16_t }

Currently all the test pass for { double, int64_t } pair.
For { float, int32_t }
Currently we can accept that Clipper2 only support { double, int64_t } version.
Default test (and Z-version):
```
[  FAILED  ] 4 tests, listed below:
[  FAILED  ] Clipper2Tests.TestCarryCalculation
[  FAILED  ] Clipper2Tests.TestIsCollinear2
[  FAILED  ] Clipper2Tests.TestOffsets3
[  FAILED  ] Clipper2Tests.TestOffsets8
```
For { float, int16_t }
```
[  FAILED  ] 10 tests, listed below:
[  FAILED  ] Clipper2Tests.TestCarryCalculation
[  FAILED  ] Clipper2Tests.TestIsCollinear2
[  FAILED  ] Clipper2Tests.TestOffsets3
[  FAILED  ] Clipper2Tests.TestOffsets4
[  FAILED  ] Clipper2Tests.TestOffsets5
[  FAILED  ] Clipper2Tests.TestOffsets8
[  FAILED  ] Clipper2Tests.TestOffsets10
[  FAILED  ] Clipper2Tests.TestMultiplePolygons
[  FAILED  ] Clipper2Tests.TestPolytreeHoles7
[  FAILED  ] Clipper2Tests.TestRectClip3
```
Results for Benchmark with fixed seed srand( 97 ):

{ double, int64_t }:
![double_int64_t](https://github.com/AngusJohnson/Clipper2/assets/4236325/f8f7ac23-ba18-4da9-86d5-7096d7c9d5b2)

{ double, int32_t }:
![double_int32_t](https://github.com/AngusJohnson/Clipper2/assets/4236325/7aa05b7b-b618-4718-ab0d-59a63a3c6f2e)

{ double, int16_t }:
![double_int16_t](https://github.com/AngusJohnson/Clipper2/assets/4236325/4b987e90-432e-4d34-9bbd-cfac4dd52b1c)

{ float, int64_t }:
![float_int64_t](https://github.com/AngusJohnson/Clipper2/assets/4236325/47fe946e-e2e8-4f7c-ab67-e0efc8c3fcc6)

{ float, int32_t }:
![float_int32_t](https://github.com/AngusJohnson/Clipper2/assets/4236325/3e4520f3-bfa4-4f18-9e5d-be69d96f4628)

{ float, int16_t }:
![float_int16_t](https://github.com/AngusJohnson/Clipper2/assets/4236325/828a27fd-bf1b-4cdd-b825-3c111208e5e8)

