### PR TITLE
Add customization point to replace math functions for platform independent results

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.h
@@ -17,6 +17,7 @@
 #include "clipper2/clipper.core.h"
 #include "clipper2/clipper.engine.h"
 #include "clipper2/clipper.offset.h"
+#include "clipper2/clipper.math.h"
 #include "clipper2/clipper.minkowski.h"
 #include "clipper2/clipper.rectclip.h"
 
@@ -598,8 +599,8 @@ namespace Clipper2Lib {
     if (steps <= 2)
       steps = static_cast<size_t>(PI * sqrt((radiusX + radiusY) / 2));
 
-    double si = std::sin(2 * PI / steps);
-    double co = std::cos(2 * PI / steps);
+    double si = Sin(2 * PI / steps);
+    double co = Cos(2 * PI / steps);
     double dx = co, dy = si;
     Path<T> result;
     result.reserve(steps);

--- a/CPP/Clipper2Lib/include/clipper2/clipper.math.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.math.h
@@ -1,0 +1,56 @@
+/*********************************************************************************
+* Author    :  Angus Johnson                                                     *
+* Date      :  24 March 2024                                                     *
+* Website   :  http://www.angusj.com                                             *
+* Copyright :  Angus Johnson 2010-2024                                           *
+* Purpose   :  Possible customization point to avoid platform dependent results  *
+* License   :  http://www.boost.org/LICENSE_1_0.txt                              *
+*********************************************************************************/
+
+#ifndef CLIPPER_MATH_H_
+#define CLIPPER_MATH_H_
+
+#include <cmath>
+
+namespace Clipper2Lib {
+
+inline double Sin(double x)
+{
+	return std::sin(x);
+}
+
+inline double Cos(double x)
+{
+	return std::cos(x);
+}
+
+inline double ACos(double x)
+{
+	return std::acos(x);
+}
+
+inline double Log10(double x)
+{
+	return std::log10(x);
+}
+
+inline double ATan2(double x, double y)
+{
+	return std::atan2(x, y);
+}
+
+// See https://stackoverflow.com/a/32436148/359538
+// This overload must not cause overflow or underflow at intermediate stages of the computation.
+inline double HypotSafe(double x, double y)
+{
+	return std::hypot(x, y);
+}
+
+// See https://stackoverflow.com/a/32436148/359538
+// This overload can cause overflow or underflow at intermediate stages of the computation.
+inline double HypotUnsafe(double x, double y)
+{	
+	return std::sqrt(x * x + y * y);
+}
+}  // end Clipper2Lib namespace
+#endif /* CLIPPER_MATH_H_ */


### PR DESCRIPTION
Hello Angus,

i'd would like to achieve platform and compiler independent results with Clipper2. One important aspect is that different compiler implementations of common math functions produce different results. Putting these functions in a common header provides a convenient way to replace them with custom functions and does not have side effects.
