### PR TITLE
Add operator+ and operator+= to Rect<T>

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.core.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.core.h
@@ -362,6 +362,22 @@ namespace Clipper2Lib
         top == other.top && bottom == other.bottom;
     }
 
+    Rect<T>& operator+=(const Rect<T>& other)
+    {
+      left = (std::min)(left, other.left);
+      top = (std::min)(top, other.top);
+      right = (std::max)(right, other.right);
+      bottom = (std::max)(bottom, other.bottom);
+      return *this;
+    }
+
+    Rect<T> operator+(const Rect<T>& other) const
+    {
+      Rect<T> result = *this;
+      result += other;
+      return result;
+    }
+
     friend std::ostream& operator<<(std::ostream& os, const Rect<T>& rect) {
       os << "(" << rect.left << "," << rect.top << "," << rect.right << "," << rect.bottom << ") ";
       return os;

--- a/CPP/Tests/TestRect.cpp
+++ b/CPP/Tests/TestRect.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+#include "clipper2/clipper.core.h"
+
+using namespace Clipper2Lib;
+
+TEST(Clipper2Tests, TestRectOpPlus)
+{
+  {
+    Rect64 lhs = Rect64::InvalidRect();
+    Rect64 rhs(-1, -1, 10, 10);
+    {
+      Rect64 sum = lhs + rhs;
+      EXPECT_EQ(rhs, sum);
+    }
+    {
+      std::swap(lhs, rhs);
+      Rect64 sum = lhs + rhs;
+      EXPECT_EQ(lhs, sum);
+    }
+  }
+  {
+    Rect64 lhs = Rect64::InvalidRect();
+    Rect64 rhs(1, 1, 10, 10);
+    {
+      Rect64 sum = lhs + rhs;
+      EXPECT_EQ(rhs, sum);
+    }
+    {
+      std::swap(lhs, rhs);
+      Rect64 sum = lhs + rhs;
+      EXPECT_EQ(lhs, sum);
+    }
+  }
+  {
+    Rect64 lhs(0, 0, 1, 1);
+    Rect64 rhs(-1, -1, 0, 0);
+    Rect64 expected(-1, -1, 1, 1);
+    {
+      Rect64 sum = lhs + rhs;
+      EXPECT_EQ(expected, sum);
+    }
+    {
+      std::swap(lhs, rhs);
+      Rect64 sum = lhs + rhs;
+      EXPECT_EQ(expected, sum);
+    }
+  }
+  {
+    Rect64 lhs(-10, -10, -1, -1);
+    Rect64 rhs(1, 1, 10, 10);
+    Rect64 expected(-10, -10, 10, 10);
+    {
+      Rect64 sum = lhs + rhs;
+      EXPECT_EQ(expected, sum);
+    }
+    {
+      std::swap(lhs, rhs);
+      Rect64 sum = lhs + rhs;
+      EXPECT_EQ(expected, sum);
+    }
+  }
+}


### PR DESCRIPTION
Hi,

i'd like to add this convenience functions. If you are interested in my usecase:
As a user of ClipperOffset it makes sense to accumulate the Rects while adding paths. Before executing i can validate, that the coordinates of the accumulated Rect plus the scaled offset are still within MAX_COORD.

Thanks, Lars