### PR TITLE
Fix C++ warnings due to missing default cases in switch statements

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.core.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.core.h
@@ -88,6 +88,9 @@ namespace Clipper2Lib
       throw Clipper2Exception(undefined_error);
     case range_error_i:
       throw Clipper2Exception(range_error);
+    // Should never happen, but adding this to stop a compiler warning
+    default:
+      throw Clipper2Exception("Unknown error");
     }
 #else
     ++error_code; // only to stop compiler warning

--- a/CPP/Clipper2Lib/src/clipper.engine.cpp
+++ b/CPP/Clipper2Lib/src/clipper.engine.cpp
@@ -928,6 +928,9 @@ namespace Clipper2Lib {
     case FillRule::Negative:
       if (e.wind_cnt != -1) return false;
       break;
+    // Should never happen, but adding this to stop a compiler warning
+    default:
+      break;
     }
 
     switch (cliptype_)
@@ -978,6 +981,9 @@ namespace Clipper2Lib {
       break;
 
     case ClipType::Xor: return true;  break;
+    // Should never happen, but adding this to stop a compiler warning
+    default:
+      break;
     }
     return false;  // we should never get here
   }


### PR DESCRIPTION
Some C++ compilers give warnings when not the default case is not covered in a switch statement over an `enum class`. Since Clipper2 sets [-Werror](https://github.com/anchpop/Clipper2/blob/c060f320530f64055980a4f53e8c95ba728f9c10/CPP/CMakeLists.txt#L76), this causes builds to fail on these compilers when using it as a dependency through cmake's `add_subdirectory`. See [GCC's -Wswitch-default docs](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wswitch-default).

Thank you for the great library by the way - been using it since the Clipper1 days.
