### PR TITLE
Installed Clipper2.pc:: Use canonical way to refer to inc and libdir

### DIFF
--- a/CPP/Clipper2.pc.cmakein
+++ b/CPP/Clipper2.pc.cmakein
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: Clipper2@PCFILE_LIB_SUFFIX@
 Description: A Polygon Clipping and Offsetting library in C++


### PR DESCRIPTION
Cmake already provides variables where the installed libraries and include directories end up, so use these for most compatible way of generating the package config.