### PR TITLE
Add non const overload PolyPath64::Polygon()

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.engine.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.engine.h
@@ -373,6 +373,8 @@ namespace Clipper2Lib {
 
 		const Path64& Polygon() const { return polygon_; };
 
+		Path64& Polygon() { return polygon_; };
+
 		double Area() const
 		{
 			return std::accumulate(childs_.cbegin(), childs_.cend(),


### PR DESCRIPTION
The PolyPath64 data structure is helpful for filtering polygons. A non const getter allows the user to consume the result and thus avoiding copies. 