### PR TITLE
Add an assertion to `ClipperOffset::Group::Group` checking that the lowest path has non-zero area

### DIFF
--- a/CPP/Clipper2Lib/src/clipper.offset.cpp
+++ b/CPP/Clipper2Lib/src/clipper.offset.cpp
@@ -9,6 +9,7 @@
 
 #include "clipper2/clipper.h"
 #include "clipper2/clipper.offset.h"
+#include "assert.h"
 
 namespace Clipper2Lib {
 
@@ -145,7 +146,9 @@ ClipperOffset::Group::Group(const Paths64& _paths, JoinType _join_type, EndType 
 		// the lowermost path must be an outer path, so if its orientation is negative,
 		// then flag the whole group is 'reversed' (will negate delta etc.)
 		// as this is much more efficient than reversing every path.
-    is_reversed = (lowest_path_idx.has_value()) && Area(paths_in[lowest_path_idx.value()]) < 0;
+		const auto lowest_path_area = Area(paths_in[lowest_path_idx.value()]);
+		assert(lowest_path_area != 0.0);
+    is_reversed = (lowest_path_idx.has_value()) && lowest_path_area < 0;
 	}
 	else
 	{


### PR DESCRIPTION
I am using `InflatePaths`, and I had the following problem that took a long time to figure out:

**Background**

The `Group` constructor currently needs to figure out if exteriors are clockwise and holes are counter-clockwise, or the other way around. It accomplishes this by finding the lowest path (=the one having the highest _y_ coordinate), because that must be an outer path, and by checking if its area is positive or negative.

**Problem**

Now if the lowest path contains only 1 or 2 points, or otherwise has zero area, and the paths are indeed "reversed", then the above logic does not work as intended.

It wouldn't be a problem to simply drop such degenerate paths, but the issue is that if the same group contains also non-degenerate, large, significant paths, they may effectively be dropped as well. This is exactly what was sometimes happening in my use case. (Just for the record, my workaround was to weed such degenerate paths from the input, before calling `InflatePaths`. Very easy once I knew what exactly the problem was, but to get to that point took quite a while...)

(Where would such degenerate paths come from? I think for example from calling OpenCV's [`findContours`](https://docs.opencv.org/4.11.0/d3/dc0/group__imgproc__shape.html#gadf1ad6a0b82947fa1fe3c3d497f260e0) for 1- or 2-pixel regions.)

**What this PR does**

This PR just adds an `assert` that should detect if the input data is such that the logic can't really work as intended. Having this available would have saved me a lot of time, so I thought it might help others who may be providing similar input data. Generally `assert`s are no-op in Release builds, so Release builds should remain unaffected. Alternatively, one could throw a `std::logic_error` or similar, but I guess that doing so would be more intrusive and might break applications that are currently working (although they would be "working" only if the paths are _not_ reversed).

**Alternative solutions**

For clarity, I think it might be best to let the user explicitly provide the orientation also in the offset case (similar to the "main" clipping functionality, such as intersection), instead of trying to figure it out from the input data. (Should be a tad faster, too?)

Another alternative would be to find the lowest path that _has non-zero area_ (instead of just the lowest path).

Angus, if you like either of the above suggestions, I can try and prepare an alternative PR.

**Unrelated remark**

(There is also a cosmetic spaces vs tabs issue here in this location, but I tried to keep the diff minimal and not start fixing that, at least for the time being.)