### PR TITLE
[cpp port] Add cmake installation configuration for Utils/ZUtils module

### DIFF
--- a/CPP/CMakeLists.txt
+++ b/CPP/CMakeLists.txt
@@ -130,9 +130,6 @@ if(CLIPPER2_UTILS OR CLIPPER2_TESTS OR CLIPPER2_EXAMPLES)
     add_library(Clipper2utils STATIC ${CLIPPER2_UTILS_INC} ${CLIPPER2_UTILS_SRC})
 
     target_link_libraries(Clipper2utils PUBLIC Clipper2)
-    target_include_directories(Clipper2utils
-      PUBLIC Utils
-    )
   endif()
 
   if (NOT (CLIPPER2_USINGZ STREQUAL "OFF"))
@@ -140,9 +137,6 @@ if(CLIPPER2_UTILS OR CLIPPER2_TESTS OR CLIPPER2_EXAMPLES)
     add_library(Clipper2Zutils STATIC ${CLIPPER2_UTILS_INC} ${CLIPPER2_UTILS_SRC})
 
     target_link_libraries(Clipper2Zutils PUBLIC Clipper2Z)
-    target_include_directories(Clipper2Zutils
-      PUBLIC Utils
-    )
   endif()
 
   set_target_properties(${CLIPPER2_UTILS} PROPERTIES FOLDER Libraries)
@@ -151,6 +145,25 @@ if(CLIPPER2_UTILS OR CLIPPER2_TESTS OR CLIPPER2_EXAMPLES)
       target_compile_options(${lib} PRIVATE -Wno-unused-variable -Wno-unused-function)
     endforeach()
   endif()
+
+  # install utils/zutils module
+  foreach(lib ${CLIPPER2_UTILS})
+    set_target_properties(${lib} PROPERTIES
+          PUBLIC_HEADER "${CLIPPER2_UTILS_INC}"
+    )
+    target_include_directories(${lib}
+      PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Utils>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/clipper2/Utils>
+    )
+    install(TARGETS ${lib}
+            EXPORT  Clipper2-targets
+            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/clipper2/Utils
+            ARCHIVE       DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY       DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME       DESTINATION ${CMAKE_INSTALL_BINDIR})
+  endforeach()
+
 endif()
 
 if(CLIPPER2_EXAMPLES)


### PR DESCRIPTION
This PR adds installation support for the Utils module and its Z-variant in CPP/CMakeLists.txt.  

There are two main changes:

1. Install rules for the Utils module (and ZUtils) have been added, so that headers and libraries are correctly deployed via `cmake install`.

2. The new targets are exported into the `Clipper2::` namespace as `Clipper2::Clipper2utils` and `Clipper2::Clipper2Zutils`.
