### PR TITLE
Fix missing VertexPoolList issue for Clipper2LibZ C# project (#1018)

### DIFF
--- a/CSharp/USINGZ/Clipper2LibZ.csproj
+++ b/CSharp/USINGZ/Clipper2LibZ.csproj
@@ -22,5 +22,6 @@
     <Compile Include="..\Clipper2Lib\Clipper.Core.cs" Link="Clipper.Core.cs" />
     <Compile Include="..\Clipper2Lib\Clipper.RectClip.cs" Link="Clipper.RectClip.cs" />
     <Compile Include="..\Clipper2Lib\Clipper.Minkowski.cs" Link="Clipper.Minkowski.cs" />
+    <Compile Include="..\Clipper2Lib\PooledList.cs" Link="PooledList.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adding a reference to the `VertexPoolList` type to the Clipper2LibZ C# project.