### PR TITLE
change namespace to Clipper2ZLib when USINGZ

### DIFF
--- a/CSharp/Clipper2Lib.Benchmark/Benchmarks.cs
+++ b/CSharp/Clipper2Lib.Benchmark/Benchmarks.cs
@@ -3,7 +3,11 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 
+#if USINGZ
+namespace Clipper2ZLib.Benchmark
+#else
 namespace Clipper2Lib.Benchmark
+#endif
 {
   public class FastConfig : ManualConfig
     {

--- a/CSharp/Clipper2Lib.Benchmark/Program.cs
+++ b/CSharp/Clipper2Lib.Benchmark/Program.cs
@@ -1,8 +1,12 @@
 using BenchmarkDotNet.Running;
 
+#if USINGZ
+namespace Clipper2ZLib.Benchmark
+#else
 namespace Clipper2Lib.Benchmark
+#endif
 {
-    public static class Program
+  public static class Program
     {        
         public static void Main()
         {

--- a/CSharp/Clipper2Lib.Examples/ConsoleDemo/Main.cs
+++ b/CSharp/Clipper2Lib.Examples/ConsoleDemo/Main.cs
@@ -8,7 +8,11 @@
 
 using System.Reflection;
 using System.IO;
+#if USINGZ
+using Clipper2ZLib;
+#else
 using Clipper2Lib;
+#endif
 using System;
 
 namespace ClipperDemo1

--- a/CSharp/Clipper2Lib.Examples/InflateDemo/Main.cs
+++ b/CSharp/Clipper2Lib.Examples/InflateDemo/Main.cs
@@ -8,7 +8,11 @@
 
 using System.IO;
 using System.Reflection;
+#if USINGZ
+using Clipper2ZLib;
+#else
 using Clipper2Lib;
+#endif
 
 namespace ClipperDemo1
 {

--- a/CSharp/Clipper2Lib.Tests/Tests2/Tests/TestZCallback1.cs
+++ b/CSharp/Clipper2Lib.Tests/Tests2/Tests/TestZCallback1.cs
@@ -2,7 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 // USINGZ compiler directive should have been set in project properties
 
-namespace Clipper2Lib.UnitTests
+namespace Clipper2ZLib.UnitTests
 {
 
   [TestClass]

--- a/CSharp/Clipper2Lib/Clipper.Core.cs
+++ b/CSharp/Clipper2Lib/Clipper.Core.cs
@@ -12,7 +12,11 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
+#if USINGZ
+namespace Clipper2ZLib
+#else
 namespace Clipper2Lib
+#endif
 {
   public struct Point64
   {

--- a/CSharp/Clipper2Lib/Clipper.Engine.cs
+++ b/CSharp/Clipper2Lib/Clipper.Engine.cs
@@ -15,7 +15,11 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
+#if USINGZ
+namespace Clipper2ZLib
+#else
 namespace Clipper2Lib
+#endif
 {
 
   // Vertex: a pre-clipping data structure. It is used to separate polygons

--- a/CSharp/Clipper2Lib/Clipper.Minkowski.cs
+++ b/CSharp/Clipper2Lib/Clipper.Minkowski.cs
@@ -10,7 +10,11 @@
 #nullable enable
 using System;
 
+#if USINGZ
+namespace Clipper2ZLib
+#else
 namespace Clipper2Lib
+#endif
 {
   public static class Minkowski
   {

--- a/CSharp/Clipper2Lib/Clipper.Offset.cs
+++ b/CSharp/Clipper2Lib/Clipper.Offset.cs
@@ -11,7 +11,11 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
+#if USINGZ
+namespace Clipper2ZLib
+#else
 namespace Clipper2Lib
+#endif
 {
   public enum JoinType
   {

--- a/CSharp/Clipper2Lib/Clipper.RectClip.cs
+++ b/CSharp/Clipper2Lib/Clipper.RectClip.cs
@@ -12,7 +12,11 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
+#if USINGZ
+namespace Clipper2ZLib
+#else
 namespace Clipper2Lib
+#endif
 {
   public class OutPt2
   {

--- a/CSharp/Clipper2Lib/Clipper.cs
+++ b/CSharp/Clipper2Lib/Clipper.cs
@@ -16,7 +16,11 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
+#if USINGZ
+namespace Clipper2ZLib
+#else
 namespace Clipper2Lib
+#endif
 {
 
   // PRE-COMPILER CONDITIONAL ...

--- a/CSharp/Clipper2Lib/HashCode.cs
+++ b/CSharp/Clipper2Lib/HashCode.cs
@@ -3,7 +3,11 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 
+#if USINGZ
+namespace Clipper2ZLib
+#else
 namespace Clipper2Lib
+#endif
 {
   /*
 

--- a/CSharp/Clipper2Lib/PooledList.cs
+++ b/CSharp/Clipper2Lib/PooledList.cs
@@ -1,8 +1,8 @@
 ﻿/*******************************************************************************
 * Author    :  Angus Johnson                                                   *
-* Date      :  10 October 2024                                                 *
+* Date      :  7 October 2025                                                 *
 * Website   :  http://www.angusj.com                                           *
-* Copyright :  Angus Johnson 2010-2024                                         *
+* Copyright :  Angus Johnson 2010-2025                                         *
 * Purpose   :  A pool of reusable vertex objects.                    *
 * Thanks    :  Special thanks to Thong Nguyen, Guus Kuiper, Phil Stopford,     *
 *           :  and Daniel Gosnell for their invaluable assistance with C#.     *
@@ -14,7 +14,11 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
+#if USINGZ
+namespace Clipper2ZLib
+#else
 namespace Clipper2Lib
+#endif
 {
   /// <summary>
   /// A pool of reusable vertex objects

--- a/CSharp/Utils/ClipFileIO/Clipper.FileIO.cs
+++ b/CSharp/Utils/ClipFileIO/Clipper.FileIO.cs
@@ -10,7 +10,11 @@ using System;
 using System.IO;
 using System.Diagnostics;
 
+#if USINGZ
+namespace Clipper2ZLib
+#else
 namespace Clipper2Lib
+#endif
 {
 
   public static class ClipperFileIO

--- a/CSharp/Utils/SVG/Clipper.SVG.Utils.cs
+++ b/CSharp/Utils/SVG/Clipper.SVG.Utils.cs
@@ -8,7 +8,11 @@
 
 using System.IO;
 
+#if USINGZ
+namespace Clipper2ZLib
+#else
 namespace Clipper2Lib
+#endif
 {
   public static class SvgUtils
   {

--- a/CSharp/Utils/SVG/Clipper.SVG.cs
+++ b/CSharp/Utils/SVG/Clipper.SVG.cs
@@ -11,7 +11,11 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 
+#if USINGZ
+namespace Clipper2ZLib
+#else
 namespace Clipper2Lib
+#endif
 {
   public class SvgWriter
   {


### PR DESCRIPTION
Adding conditional compilation for C# Clipper2lib to change the namespace from Clipper2Lib to Clipper2ZLib when USINGZ. This prepares to allow both variants to be packaged and deployed via Nuget.
This is a (small) breaking change for users importing Clipper with USINGZ defined. They have to change  "using Clipper2Lib;" to "using Clipper2ZLib;"
Preperation for resolving #1012 

below my example powershell deploy script to deploy both variants with a single script
```
dotnet build Clipper2lib.csproj -c Release
dotnet pack Clipper2lib.csproj -c Release  --output "Nuget" -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg /p:Version=1.5.5

dotnet build Clipper2lib.csproj -c Release -p:DefineConstants="USINGZ" -p:PackageId=Clipper2Z -p:Title=Clipper2Z -p:AssemblyName=Clipper2Z
dotnet pack Clipper2lib.csproj -c Release  --output "Nuget" -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:PackageId=Clipper2Z -p:Title=Clipper2Z -p:AssemblyName=Clipper2Z /p:Version=1.5.5
dotnet nuget push Nuget\*.nupkg --api-key ${{secrets.NUGET_DEPLOY_KEY}} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
```
This script overrides AssemblyName, PackageId and Title to be **Clipper2Z** instead of **Clipper2**.  Overwritting AssemblyName will create **Clipper2Z.dll** which can be used at the same time as **Clipper2.dll** when importing both packages, the name must differ for this to work. I tested packaging with a private Gitlab package registry, it should all work the same way for Nuget.org.

The secret NUGET_DEPLOY_KEY has to be inserted for the push and the version has to be changed (or read from somewhere else with the script).

I'm not sure which debug symbols format Clipper2 deployment is currently using, I put snupkg format which is recommended by Nuget.org.