### PR TITLE
Add msys2 test

### DIFF
--- a/.github/workflows/actions_cpp.yml
+++ b/.github/workflows/actions_cpp.yml
@@ -3,7 +3,7 @@ on:
   push:
   pull_request:
 jobs:
-  windows-latest:
+  windows-msvc:
     runs-on: 'windows-latest'
     steps:
     - uses: actions/checkout@v4
@@ -22,6 +22,32 @@ jobs:
       run: |
         cd CPP/build
         ctest . -C RelWithDebInfo --output-on-failure
+  windows-msys2:
+    runs-on: 'windows-latest'
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: UCRT64
+        update: true
+        pacboy: >-
+          git:
+          make:
+          toolchain:p
+          cmake:p
+    - name: Build
+      run: |
+        mkdir CPP/build
+        cd CPP/build
+        cmake .. -G "MSYS Makefiles" -DCLIPPER2_TESTS=ON
+        cmake --build . --parallel
+    - name: Run tests
+      run: |
+        cd CPP/build
+        ctest . --output-on-failure
   ubuntu-latest-gcc-default:
     runs-on: 'ubuntu-latest'
     steps:


### PR DESCRIPTION
Adding a gcc test on Windows to improve test coverage.
Two interesting observations:
* #1029 doesn't fail on gcc on Windows
* However, a bunch of other tests fail, which looks suspicious.