### PR TITLE
Fix uninitialized memory read

### DIFF
--- a/CPP/Clipper2Lib/src/clipper.triangulation.cpp
+++ b/CPP/Clipper2Lib/src/clipper.triangulation.cpp
@@ -1202,7 +1202,7 @@ namespace Clipper2Lib
 
   TriangulateResult Triangulate(const PathsD& pp, int decPlaces, PathsD& solution, bool useDelaunay)
   {
-    int ec;
+    int ec = 0;
     double scale;
     TriangulateResult result;
     if (decPlaces <= 0) scale = 1;

--- a/CPP/Examples/Inflate/Inflate.cpp
+++ b/CPP/Examples/Inflate/Inflate.cpp
@@ -86,7 +86,7 @@ static void DoSimpleShapes()
   // POLYGON JOINTYPES SVG:
 
   // 1. triangle offset - with large miter
-  int err, scale = 100;
+  int err = 0, scale = 100;
   PathsD p, solution;
   p.push_back(MakePathD({ 30,150, 60,350, 0,350 }));
   solution.insert(solution.end(), p.begin(), p.end());

--- a/CPP/Tests/TestOffsets.cpp
+++ b/CPP/Tests/TestOffsets.cpp
@@ -46,7 +46,7 @@ TEST(Clipper2Tests, TestOffsets2) { // see #448 & #456
   Paths64 subject, solution;
   ClipperOffset c;
   subject.push_back(MakePath({ 50,50, 100,50, 100,150, 50,150, 0,100 }));
-  int err;
+  int err = 0;
   subject = ScalePaths<int64_t, int64_t>(subject, scale, err);
   c.AddPaths(subject, JoinType::Round, EndType::Polygon);
   c.ArcTolerance(arc_tol);


### PR DESCRIPTION
Fixes #1052

This is a clear uninitialized memory read.

Note that some compilers are able to detect this kind of memory access through static analysis when `-Wall` is enabled (specifically through `-Werror=maybe-uninitialized`). However, the capabilities of this features varies between compiler versions. `gcc-11.4.0` in Ubuntu-22.04 seems to be particularly good at this, but this compiler is not used by Clipper's CI, which is why this issue went undetected.