### PR TITLE
Preserve Z values at line intersections instead of zeroing them

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.core.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.core.h
@@ -942,7 +942,23 @@ namespace Clipper2Lib
       ip.y = originy + static_cast<T>(hity);
     }
 #ifdef USINGZ
-    ip.z = 0;
+    // Interpolate Z from ln1 endpoints based on proximity along segment
+    {
+      double seg_dx = static_cast<double>(ln1b.x - ln1a.x);
+      double seg_dy = static_cast<double>(ln1b.y - ln1a.y);
+      double seg_len_sq = seg_dx * seg_dx + seg_dy * seg_dy;
+      if (seg_len_sq > 0.0)
+      {
+        double pt_dx = static_cast<double>(ip.x - ln1a.x);
+        double pt_dy = static_cast<double>(ip.y - ln1a.y);
+        double t_z = (pt_dx * seg_dx + pt_dy * seg_dy) / seg_len_sq;
+        ip.z = (t_z <= 0.5) ? ln1a.z : ln1b.z;
+      }
+      else
+      {
+        ip.z = ln1a.z;
+      }
+    }
 #endif
     return true;
 }
@@ -967,7 +983,7 @@ namespace Clipper2Lib
       ip.x = static_cast<T>(ln1a.x + t * dx1);
       ip.y = static_cast<T>(ln1a.y + t * dy1);
 #ifdef USINGZ
-      ip.z = 0;
+      ip.z = (t <= 0.5) ? ln1a.z : ln1b.z;
 #endif
     }
     return true;


### PR DESCRIPTION
When USINGZ is enabled, GetLineIntersectPt sets ip.z = 0 for true intersection points (where t is strictly between 0 and 1). This discards user data stored in Z before the ZCallback has a chance to run, which matters for code paths like RectClip that don't use a ZCallback at all. Pick the nearer endpoint's Z value instead. 