### PR TITLE
Add Swift port to third-party ports list

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,5 +99,6 @@ https://github.com/AngusJohnson/Clipper2/blob/2970649befb89af85e2132e5242a7d6926
 | **Kotlin** | https://github.com/Monkey-Maestro/clipper2-kotlin |
 | **Lua** | https://github.com/Ark223/Clipper2-Lua |
 | **Rust** | https://github.com/larsbrubaker/clipper2-rust |
+| **Swift** | https://github.com/zyunlongz/clipper2-swift |
 | **TypeScript** | https://github.com/countertype/clipper2-ts |
 | **WASM** | https://github.com/ErikSom/Clipper2-WASM/ |


### PR DESCRIPTION
## Summary
- Add [clipper2-swift](https://github.com/zyunlongz/clipper2-swift) to the community ports table in README.md

This is a pure Swift port of Clipper2, covering core clipping and offsetting functionality.