### PR TITLE
fix project path for C# tests

### DIFF
--- a/CSharp/Tests/README.md
+++ b/CSharp/Tests/README.md
@@ -1,0 +1,21 @@
+# Running C# Tests
+
+Requires [.NET SDK](https://dotnet.microsoft.com/download) (6.0+).
+
+## Run all tests
+
+```bash
+dotnet test CSharp/Tests/Tests1/Tests1.csproj
+dotnet test CSharp/Tests/Tests2/TestsZ.csproj
+```
+
+## Run a specific test project
+
+| Project | What it covers |
+|---------|----------------|
+| `Tests1` | Core clipping, offsets, polytree, open paths |
+| `Tests2` (TestsZ) | Z-callback / USINGZ functionality |
+
+## Useful flags
+
+

--- a/CSharp/Tests/Tests2/TestsZ.csproj
+++ b/CSharp/Tests/Tests2/TestsZ.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\USINGZ\Clipper2LibZ.csproj" />
+    <ProjectReference Include="..\..\USINGZ\Clipper2Lib_Z.csproj" />
     <ProjectReference Include="..\..\Utils\ClipFileIO\Clipper.FileIO.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
fix project path for C# tests see https://github.com/AngusJohnson/Clipper2/issues/1081
add readme on tests